### PR TITLE
Rdb stall

### DIFF
--- a/appconfig/clusters.csv
+++ b/appconfig/clusters.csv
@@ -1,7 +1,7 @@
 cluster_name,cluster_type,proctype,procname,toload,args
 hdb,GP,hdb,hdb1,${KDBHDB},
 discovery,GP,discovery,discovery1,${KDBCODE}/processes/discovery.q,
-rdb,GP,rdb,rdb1,${KDBCODE}/processes/rdb.q,
+rdb,RDB,rdb,rdb1,${KDBCODE}/processes/rdb.q,
 feed,GP,tradeFeed,tradeFeed1,${KDBAPPCODE}/processes/tradeFeed.q,
 gateway,GP,gateway,gateway1,${KDBCODE}/processes/gateway.q,
 wdb,GP,wdb,wdb1,${KDBCODE}/processes/wdb.q,

--- a/appconfig/settings/rdb.q
+++ b/appconfig/settings/rdb.q
@@ -13,7 +13,6 @@ reloadenabled:0b                    // if true, the RDB will not save when .u.en
 timeout:system"T"
 connectonstart:0b                   // rdb connects and subscribes to tickerplant on startup
 tickerplanttypes:`segmentedtickerplant
-gatewatypes:`none
 replaylog:0b                        //disable intital log replay - we dont want data until the need period begins
 upd:{[t;x]};                        //discard initial data from subscriptions until start of new period
 

--- a/appconfig/settings/rdb.q
+++ b/appconfig/settings/rdb.q
@@ -25,4 +25,4 @@ subfiltered:0b
 subcsv:hsym first `.proc.getconfigfile["rdbsub/rdbsub",(3_string .proc`procname),".csv"];
 
 \d .servers
-CONNECTIONS:`rdb`wdb`gateway         // if connectonstart false,include tickerplant in tickerplanttypes, not in CONNECTIONS
+CONNECTIONS:`rdb`wdb               // if connectonstart false,include tickerplant in tickerplanttypes, not in CONNECTIONS

--- a/appconfig/settings/rdb.q
+++ b/appconfig/settings/rdb.q
@@ -14,10 +14,15 @@ timeout:system"T"
 connectonstart:0b                   // rdb connects and subscribes to tickerplant on startup
 tickerplanttypes:`segmentedtickerplant
 gatewatypes:`none
-replaylog:1b
+replaylog:0b                        //disable intital log replay - we dont want data until the need period begins
+upd:{[t;x]};                        //discard initial data from subscriptions until start of new period
+
 
 hdbtypes:()                         //connection to HDB not needed
 
 subfiltered:0b
 // path to rdbsub{i}.csv
 subcsv:hsym first `.proc.getconfigfile["rdbsub/rdbsub",(3_string .proc`procname),".csv"];
+
+\d .servers
+CONNECTIONS:`rdb`wdb`gateway         // if connectonstart false,include tickerplant in tickerplanttypes, not in CONNECTIONS

--- a/appconfig/settings/wdb.q
+++ b/appconfig/settings/wdb.q
@@ -3,3 +3,5 @@
 replay:0b;     // We don't want to replay as the wdb will start before the period it is meant to subscribe to
 upd:{[t;x]};   //Discard data until the end of period signals the start of new period
 
+\d .servers
+CONNECTIONS:`segmentedtickerplant`sort`gateway`rdb`hdb    //overwrite .server.Connections so the  wdb connects to the old (previous period) rdb on start up

--- a/appconfig/settings/wdb.q
+++ b/appconfig/settings/wdb.q
@@ -2,3 +2,4 @@
 \d .wdb
 replay:0b;     // We don't want to replay as the wdb will start before the period it is meant to subscribe to
 upd:{[t;x]};   //Discard data until the end of period signals the start of new period
+ 

--- a/appconfig/settings/wdb.q
+++ b/appconfig/settings/wdb.q
@@ -2,6 +2,3 @@
 \d .wdb
 replay:0b;     // We don't want to replay as the wdb will start before the period it is meant to subscribe to
 upd:{[t;x]};   //Discard data until the end of period signals the start of new period
-
-\d .servers
-CONNECTIONS:`segmentedtickerplant`sort`gateway`rdb`hdb    //overwrite .server.Connections so the  wdb connects to the old (previous period) rdb on start up

--- a/appconfig/settings/wdb.q
+++ b/appconfig/settings/wdb.q
@@ -2,4 +2,4 @@
 \d .wdb
 replay:0b;     // We don't want to replay as the wdb will start before the period it is meant to subscribe to
 upd:{[t;x]};   //Discard data until the end of period signals the start of new period
- 
+


### PR DESCRIPTION
1. Change rdb cluster type to RDB to allow use of new rdb cluster on finspace.
2. Change replaylog to 0b to disable intia;l replay when process comes up (as this will be prior to period start)
3. Change upd to discard any incoming data (this will be reverted later at period start/end)
4. Add wdb and rdb to the conneciton list for the new rdb in order to facilitate sending 'ready' message.