### PR TITLE
Remove clusters csv tor q fin space

### DIFF
--- a/appconfig/clusters.csv
+++ b/appconfig/clusters.csv
@@ -1,7 +1,0 @@
-cluster_name,cluster_type,proctype,procname,toload,args
-hdb,GP,hdb,hdb1,${KDBHDB},
-discovery,GP,discovery,discovery1,${KDBCODE}/processes/discovery.q,
-rdb,RDB,rdb,rdb1,${KDBCODE}/processes/rdb.q,
-feed,GP,tradeFeed,tradeFeed1,${KDBAPPCODE}/processes/tradeFeed.q,
-gateway,GP,gateway,gateway1,${KDBCODE}/processes/gateway.q,
-wdb,GP,wdb,wdb1,${KDBCODE}/processes/wdb.q,

--- a/appconfig/process.csv
+++ b/appconfig/process.csv
@@ -3,4 +3,6 @@ localhost,{KDBBASEPORT}+1,discovery,discovery1,,1,0,,,${KDBCODE}/processes/disco
 localhost,{KDBBASEPORT}+2,rdb,rdb1,,1,1,180,,${KDBCODE}/processes/rdb.q,1,,q
 localhost,{KDBBASEPORT}+3,hdb,hdb1,,1,1,60,4000,${KDBHDB},1,,q
 localhost,{KDBBASEPORT}+7,gateway,gateway1,,1,1,,4000,${KDBCODE}/processes/gateway.q,1,,q
+localhost,{KDBBASEPORT}+8,wdb,wdb1,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
 localhost,{KDBBASEPORT}+9,monitor,monitor1,,1,0,,,${KDBCODE}/processes/monitor.q,1,,q
+localhost,{KDBBASEPORT}+10,tradeFeed,tradeFeed1,,1,0,,,${KDBAPPCODE}/processes/tradeFeed.q,1,,q

--- a/appconfig/settings/default.q
+++ b/appconfig/settings/default.q
@@ -3,18 +3,16 @@ system"c 23 2000"
 .usage.logtodisk:0b; / disable usage logging as we cannot write to disk in finspace
 
 .servers.FINSPACEDISC:1b;
-.servers.FINSPACECLUSTERSFILE:hsym `$getenv[`KDBAPPCONFIG],"/clusters.csv"
 
-.servers.CLUSTERS:("SSSS**"; enlist ",") 0: .servers.FINSPACECLUSTERSFILE;
-.servers.SOCKETTYPE:{x!count[x]#`finspace} exec distinct proctype from .servers.CLUSTERS;
+.servers.SOCKETTYPE:{x!count[x]#`finspace} exec distinct proctype from .servers.procstab:("S*SS*BBHH*B**";enlist ",") 0: .proc.file;
 
 .finspace.enabled:1b;
 
 // hb subscriptions keeps the connections alive
 .hb.subenabled:1b;
 
-svrstoload:select from .servers.CLUSTERS where proctype = .proc.proctype
-$[count toload:first exec toload from svrstoload where procname = .proc.procname;
+svrstoload:select from .servers.procstab where proctype = .proc.proctype;
+$[count toload:first ?[svrstoload;enlist (=;`procname;(),.proc.procname);();`load];
   .proc.params[`load]:enlist .rmvr.removeenvvar toload;
-  if[count svrstoload; .proc.params[`load]:enlist .rmvr.removeenvvar first exec toload from svrstoload]
+  if[count svrstoload; .proc.params[`load]:enlist .rmvr.removeenvvar first ?[svrstoload;();();`load]]
  ];

--- a/appconfig/settings/default.q
+++ b/appconfig/settings/default.q
@@ -4,6 +4,7 @@ system"c 23 2000"
 
 .servers.FINSPACEDISC:1b;
 
+//-- .servers.procstab to be later overwritten in trackservers.q
 .servers.SOCKETTYPE:{x!count[x]#`finspace} exec distinct proctype from .servers.procstab:("S*SS*BBHH*B**";enlist ",") 0: .proc.file;
 
 .finspace.enabled:1b;

--- a/appconfig/settings/default.q
+++ b/appconfig/settings/default.q
@@ -13,7 +13,7 @@ system"c 23 2000"
 .hb.subenabled:1b;
 
 svrstoload:select from .servers.procstab where proctype = .proc.proctype;
-$[count toload:first ?[svrstoload;enlist (=;`procname;(),.proc.procname);();`load];
+$[count toload:first (select from svrstoload where procname=.proc.procname)`load;
   .proc.params[`load]:enlist .rmvr.removeenvvar toload;
-  if[count svrstoload; .proc.params[`load]:enlist .rmvr.removeenvvar first ?[svrstoload;();();`load]]
+  if[count svrstoload; .proc.params[`load]:enlist .rmvr.removeenvvar first svrstoload`load]
  ];

--- a/appconfig/settings/default.q
+++ b/appconfig/settings/default.q
@@ -4,7 +4,7 @@ system"c 23 2000"
 
 .servers.FINSPACEDISC:1b;
 
-//-- .servers.procstab to be later overwritten in trackservers.q
+//-- .servers.procstab will be overwritten by trackservers.q on servers initiation
 .servers.SOCKETTYPE:{x!count[x]#`finspace} exec distinct proctype from .servers.procstab:("S*SS*BBHH*B**";enlist ",") 0: .proc.file;
 
 .finspace.enabled:1b;


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

remove clusters.csv. Use process.csv as default config file for initialization in finspace