### PR TITLE
Finspace unregister from gw

### DIFF
--- a/appconfig/settings/gateway.q
+++ b/appconfig/settings/gateway.q
@@ -1,2 +1,3 @@
 \d .gw
-synccallsallowed:1b		// whether synchronous calls are allowed
+synccallsallowed:1b;		// whether synchronous calls are allowed
+DEREGCHECKFREQ:0D00:00:10;  // frequency of the deregister timer

--- a/code/gateway/deregister.q
+++ b/code/gateway/deregister.q
@@ -48,5 +48,5 @@ addserversfromconnectiontable:{
     if[(dict`flagdown) or (null first exec handle from .gw.servers where serverid=id); :id];
     
     // if no other servers of this serverType are active, wait. Else, signal shutdown
-    $[count select from .gw.servers where active, servertype=dict`servertype; [neg[dict`handle]"exit 0"; :id]; ()]
+    $[count select from .gw.servers where active, servertype=dict`servertype; [neg[dict`handle](`.finspace.deletecluster;""); :id]; ()]
   };

--- a/code/gateway/deregister.q
+++ b/code/gateway/deregister.q
@@ -48,5 +48,5 @@ addserversfromconnectiontable:{
     if[(dict`flagdown) or (null first exec handle from .gw.servers where serverid=id); :id];
     
     // if no other servers of this serverType are active, wait. Else, signal shutdown
-    $[count select from .gw.servers where active, servertype=dict`servertype, handle<>dict`handle; [neg[dict`handle]"exit 0"; :id]; ()]
+    $[count select from .gw.servers where active, servertype=dict`servertype; [neg[dict`handle]"exit 0"; :id]; ()]
   };

--- a/code/gateway/deregister.q
+++ b/code/gateway/deregister.q
@@ -1,0 +1,43 @@
+
+.gw.DEREGCHECKFREQ:@[value;`.gw.DEREGCHECKFREQ;0D00:00:10];
+
+.finspace.unregisterfromgw:{[servernames]
+   // identify the serverid by mapping the handles in .server.SERVERS and .gw.servers
+   svrIDs:exec serverid from deregservers:(select handle:w, procname from .servers.SERVERS where procname in servernames, not null w) ij `handle xkey .gw.servers;
+   if[not count svrIDs; .lg.o[`unregisterfromgw;"No servers to deregister. Aborting"]; :()];
+
+   // block incoming queries to these processes
+   update active:0b from `.gw.servers where serverid in svrIDs;
+   
+   timerID:first 1?0Ng;
+   .timer.repeat[.proc.cp[];0Wp;.gw.DEREGCHECKFREQ;(`.finspace.checkremainingqueries;timerID;svrIDs;update flagdown:0b from deregservers);"check if pending queries in servernames"]
+ };
+
+// timerid     | -2h | guid identifier to help remove instance of this function if multiple instances of this function are scheduled
+// serversid   | 6h  | ids of the servers to deregister
+// serversinfo | 98h | table with info about the servers to deregister
+.finspace.checkremainingqueries:{[timerid;serverids;serversinfo]
+   whereComplete:serverids where .finspace.checkremainingqueriesforserver each serverids;
+   serversinfo:update flagdown:1b from serversinfo where serverid in raze @'[.finspace.sigserverexit[;serversinfo];whereComplete;{:()}];
+
+   if[all serversinfo`flagdown;
+      .timer.remove @/: exec id from .timer.timer where `.finspace.checkremainingqueries in' funcparam, timerid in' funcparam;
+      :(::);
+     ]; 
+
+   if[count incompleteservers:exec procname from serversinfo where not serverid in whereComplete;
+      .lg.o[`checkremainingqueries;"servers ",(.Q.s1 incompleteservers), " still have remaining queries"]];
+ };
+
+.finspace.checkremainingqueriesforserver:{[serverid]
+   not count where {[dict;id] byId:where id=dict[1;;0]; not all dict[1;byId;2] }[;serverid] each .gw.results _ 0Ni
+ };
+
+.finspace.sigserverexit:{[id;sInfo]
+    dict:first select from sInfo where serverid=id;
+
+    // if this server was already shutdown or has disconnected for any reason, return the serverid
+    if[(dict`flagdown) or (null first exec handle from .gw.servers where serverid=id); :id];
+    
+    $[count select from .gw.servers where active, servertype=dict`servertype, handle<>dict`handle; [neg[dict`handle]"exit 0"; :id]; ()]
+  };

--- a/code/gateway/deregister.q
+++ b/code/gateway/deregister.q
@@ -1,5 +1,13 @@
 
-.gw.DEREGCHECKFREQ:@[value;`.gw.DEREGCHECKFREQ;0D00:00:10];
+/d .gw
+
+DEREGCHECKFREQ:@[value;`.gw.DEREGCHECKFREQ;0D00:00:10];
+
+//overwrite this method to not upsert null handles??
+addserversfromconnectiontable:{
+ {.gw.addserverattr'[x`w;x`proctype;x`attributes]}[select w,proctype,attributes from .servers.SERVERS where ((proctype in x) or x~`ALL),not w in ((0;0Ni),exec handle from .gw.servers where not null handle)];}
+
+/d .
 
 .finspace.unregisterfromgw:{[servernames]
    // identify the serverid by mapping the handles in .server.SERVERS and .gw.servers
@@ -39,5 +47,6 @@
     // if this server was already shutdown or has disconnected for any reason, return the serverid
     if[(dict`flagdown) or (null first exec handle from .gw.servers where serverid=id); :id];
     
+    // if no other servers of this serverType are active, wait. Else, signal shutdown
     $[count select from .gw.servers where active, servertype=dict`servertype, handle<>dict`handle; [neg[dict`handle]"exit 0"; :id]; ()]
   };

--- a/code/gateway/deregister.q
+++ b/code/gateway/deregister.q
@@ -15,7 +15,7 @@ addserversfromconnectiontable:{
    if[not count svrIDs; .lg.o[`unregisterfromgw;"No servers to deregister. Aborting"]; :()];
 
    // block incoming queries to these processes
-   update active:0b from `.gw.servers where serverid in svrIDs;
+   update active:0b,disconnecttime:.proc.cp[] from `.gw.servers where serverid in svrIDs;
    
    timerID:first 1?0Ng;
    .timer.repeat[.proc.cp[];0Wp;.gw.DEREGCHECKFREQ;(`.finspace.checkremainingqueries;timerID;svrIDs;update flagdown:0b from deregservers);"check if pending queries in servernames"]

--- a/code/gateway/deregister.q
+++ b/code/gateway/deregister.q
@@ -1,5 +1,5 @@
 
-/d .gw
+\d .gw
 
 DEREGCHECKFREQ:@[value;`.gw.DEREGCHECKFREQ;0D00:00:10];
 
@@ -7,7 +7,7 @@ DEREGCHECKFREQ:@[value;`.gw.DEREGCHECKFREQ;0D00:00:10];
 addserversfromconnectiontable:{
  {.gw.addserverattr'[x`w;x`proctype;x`attributes]}[select w,proctype,attributes from .servers.SERVERS where ((proctype in x) or x~`ALL),not w in ((0;0Ni),exec handle from .gw.servers where not null handle)];}
 
-/d .
+\d .
 
 .finspace.unregisterfromgw:{[servernames]
    // identify the serverid by mapping the handles in .server.SERVERS and .gw.servers

--- a/terraform-deployment/environment/main.tf
+++ b/terraform-deployment/environment/main.tf
@@ -224,7 +224,8 @@ data "aws_iam_policy_document" "iam-policy" {
   statement {
     effect  = "Allow"
     actions = [
-      "finspace:ConnectKxCluster"
+      "finspace:ConnectKxCluster",
+      "finspace:DeleteKxCluster"
     ]
     resources = [
       "${aws_finspace_kx_environment.environment.arn}/kxCluster/*"
@@ -238,6 +239,24 @@ data "aws_iam_policy_document" "iam-policy" {
     ]
     resources = [
       "${aws_finspace_kx_environment.environment.arn}/kxCluster/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeTags"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteVpcEndpoints"
+    ]
+    resources = [
+      "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:vpc-endpoint/*"
     ]
   }
 }


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

Adds a timer to shutdown finspace clusters from the gateway based on serverName

## Changes
- new file called deregister.q, containing code to deregister servers running on finspace clusters
- overwriting addserversfromconnectiontable to ignore non-active connections with a valid handle when a new connection is made
- terraform code to add permission to our finspace execution_role to 