### PR TITLE
enhancements for configuring wdb_log_groups

### DIFF
--- a/terraform-deployment/deployments/terraform.tfvars
+++ b/terraform-deployment/deployments/terraform.tfvars
@@ -21,7 +21,7 @@ send-sns-alert    = false                                      # true=create ema
 alert-smpt-target = "your.name@dataintellect.com"              # email address to send sns alerts to if send-alert flag is set to 'true'
 
 # metricfilter configs
-wdb_log_groups = []                                         # configure EXISTING log groups with names like "wdb*" here eg. ["wdb","wdb2"]
+wdb_log_groups = ["wdb1","wdb2"]                               # configure log groups with prefix "wdb" here eg. ["wdb1","wdb2"]
 
 # database name
 database-name     = "finspace-database"                        # database name should match name specified in env.q 

--- a/terraform-deployment/metricfilter/main.tf
+++ b/terraform-deployment/metricfilter/main.tf
@@ -13,21 +13,26 @@ variable "eventBridge_role_arn" {
 
 variable "wdb_log_groups" {
   type        = list
-  description = "list of existing log group names like 'wdb*'"
+  description = "list of log groups with prefix 'wdb'"
+}
+
+data "aws_cloudwatch_log_groups" "aws_log_groups" {
+  log_group_name_prefix = "/aws/vendedlogs/finspace/${var.environment-id}/wdb"
 }
 
 locals {
     metric-filter-name = "wdb_eop_shutdown_msg"
-    //wdb_cluster_names  = concat(["wdb"],[for i in range(var.rdbCntr_mod) : format("wdb%d",i+1)]) ## uncomment when ready
+    log-prefix         = "/aws/vendedlogs/finspace/${var.environment-id}"
+    wdb_log_groups     = [for name in var.wdb_log_groups: name if contains(data.aws_cloudwatch_log_groups.aws_log_groups.log_group_names,"${local.log-prefix}/${name}")]
 }
 
 data "aws_cloudwatch_log_group" "wdb_log_groups" {
-  for_each   = toset(var.wdb_log_groups)
-  name       = "/aws/vendedlogs/finspace/${var.environment-id}/${each.value}"
+  for_each   = toset(local.wdb_log_groups)
+  name       = "${local.log-prefix}/${each.value}"
 }
 
 resource "aws_cloudwatch_log_metric_filter" "wdb_log_monit" {
-    for_each       = toset(var.wdb_log_groups)
+    for_each       = toset(local.wdb_log_groups)
     name           = local.metric-filter-name
     pattern        = "new rdb ready. create new hdb"             ##hard coded for now, but eventually this should be a configurable variable
     log_group_name = data.aws_cloudwatch_log_group.wdb_log_groups[each.value].name
@@ -42,7 +47,7 @@ resource "aws_cloudwatch_log_metric_filter" "wdb_log_monit" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wdb_log_monit_alarm" {
-  count = length(var.wdb_log_groups) > 0 ? 1 : 0
+  count = length(local.wdb_log_groups) > 0 ? 1 : 0
   alarm_name = "${local.metric-filter-name}_alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods = 1
@@ -56,7 +61,7 @@ resource "aws_cloudwatch_metric_alarm" "wdb_log_monit_alarm" {
 }
 
 resource "aws_cloudwatch_event_rule" "wdb_log_monit_rule" {
-  count = length(var.wdb_log_groups) > 0 ? 1 : 0
+  count = length(local.wdb_log_groups) > 0 ? 1 : 0
   name = "${local.metric-filter-name}_rule"
   description = "trigger lambda when ${local.metric-filter-name} finds any matches"
 
@@ -73,7 +78,7 @@ resource "aws_cloudwatch_event_rule" "wdb_log_monit_rule" {
 }
 
 resource "aws_cloudwatch_event_target" "wdb_log_monit_rule_target" {
-  count = length(var.wdb_log_groups) > 0 ? 1 : 0
+  count = length(local.wdb_log_groups) > 0 ? 1 : 0
   arn = var.sfn_state_machine_arn
   rule = aws_cloudwatch_event_rule.wdb_log_monit_rule[0].name
   role_arn = var.eventBridge_role_arn


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

values in "wdb_log_groups" will be checked against existing log groups in AWS and filtered out if they do not exist. Users no longer have to worry about terraform erroring if the configured log groups names don't match those already in AWS