### PR TITLE
FinTorq feed to use .servers.SERVERS

### DIFF
--- a/appconfig/settings/tradeFeed.q
+++ b/appconfig/settings/tradeFeed.q
@@ -4,4 +4,4 @@
 
 \d .servers
 
-CONNECTIONS:enlist `gateway         // if connectonstart false, include tickerplant in tickerplanttypes, not in CONNECTIONS
+CONNECTIONS:enlist `gateway`rdb         // if connectonstart false, include tickerplant in tickerplanttypes, not in CONNECTIONS

--- a/appconfig/settings/tradeFeed.q
+++ b/appconfig/settings/tradeFeed.q
@@ -1,6 +1,5 @@
 //TODO this can be changed or removed to work with discovery once unblocked
 .feed.clusters:enlist `$"rdb1";
-.trade.rdbHandles:();
 
 \d .servers
 

--- a/appconfig/settings/tradeFeed.q
+++ b/appconfig/settings/tradeFeed.q
@@ -1,5 +1,6 @@
 //TODO this can be changed or removed to work with discovery once unblocked
-.feed.clusters:enlist `$"rdb"
+.feed.clusters:enlist `$"rdb1";
+.trade.rdbHandles:();
 
 \d .servers
 

--- a/appconfig/settings/tradeFeed.q
+++ b/appconfig/settings/tradeFeed.q
@@ -4,4 +4,4 @@
 
 \d .servers
 
-CONNECTIONS:enlist `gateway`rdb         // if connectonstart false, include tickerplant in tickerplanttypes, not in CONNECTIONS
+CONNECTIONS:`gateway`rdb         // if connectonstart false, include tickerplant in tickerplanttypes, not in CONNECTIONS

--- a/appconfig/settings/tradeFeed.q
+++ b/appconfig/settings/tradeFeed.q
@@ -1,5 +1,3 @@
-//TODO this can be changed or removed to work with discovery once unblocked
-.feed.clusters:enlist `$"rdb1";
 
 \d .servers
 

--- a/code/processes/tradeFeed.q
+++ b/code/processes/tradeFeed.q
@@ -40,9 +40,11 @@ timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push 
 //TODO derive rdb handles through discovery cluster instead of generating
 
 .trade.updateRDB:{
- rdbHandles:@[{hopen .aws.get_kx_connection_string[x]};;.lg.o[`updateRDB;"failed to get handle(s)"]] each .feed.clusters;
+ if[not count .trade.rdbHandles; 
+  .trade.rdbHandles:@[{hopen .aws.get_kx_connection_string[x]};;.lg.o[`updateRDB;"failed to get handle(s)"]] each .feed.clusters];
  tradedata:.trade.generateData[.feed.nq;.feed.nt;.feed.randomcounts];
- {[handle;data].trade.upd[handle;;]'[key data;value data]}[;tradedata] each rdbHandles
+ tradedata[`trades]:delete from tradedata[`trades] where null price;
+ {[handle;data].trade.upd[handle;;]'[key data;value data]}[;tradedata] each .trade.rdbHandles
   };
 
 .trade.endofday:{

--- a/code/processes/tradeFeed.q
+++ b/code/processes/tradeFeed.q
@@ -40,7 +40,7 @@ timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push 
 //TODO derive rdb handles through discovery cluster instead of generating
 
 .trade.updateRDB:{
-  rdbHandles:exec w from .servers.SERVERS where procname in .feed.clusters, .dotz.liveh w;
+  rdbHandles:exec w from .servers.SERVERS where proctype in `rdb, .dotz.liveh w;
   if[not count rdbHandles; .lg.e[`updateRDB;"no valid handles amongst subscribers"]; :()];
   tradedata:.trade.generateData[.feed.nq;.feed.nt;.feed.randomcounts];
   tradedata[`trades]:delete from tradedata[`trades] where null price;
@@ -48,7 +48,7 @@ timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push 
   };
 
 .trade.endofday:{
- rdbHandles:exec w from .servers.SERVERS where procname in .feed.clusters, .dotz.liveh w;
+ rdbHandles:exec w from .servers.SERVERS where proctype in `rdb, .dotz.liveh w;
  if[not count rdbHandles; .lg.e[`endofday;"no valid handles amongst subscribers. Try again later"]; :()];
  {[handle;dt] (neg first handle)(`.u.end;dt)}[;.proc.cd[]] each rdbHandles
   };

--- a/code/processes/tradeFeed.q
+++ b/code/processes/tradeFeed.q
@@ -5,7 +5,6 @@
 nq:@[value;`nq;100];                                //number of quotes to generate
 nt:@[value;`nt;100];                                //number of trades to generate
 randomcounts:@[value;`randomcounts;0.00000001];
-clusters:@[value;`clusters;enlist `cluster];        //which rdb cluster or clusters to point the data to
 rnd:{0.01*floor 100*x};
 timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push new dummy data to the rdb clusters
 

--- a/code/processes/tradeFeed.q
+++ b/code/processes/tradeFeed.q
@@ -40,7 +40,7 @@ timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push 
 //TODO derive rdb handles through discovery cluster instead of generating
 
 .trade.updateRDB:{
-  rdbHandles:exec w from .servers.SERVERS where procname in .feed.clusters, not null w;
+  rdbHandles:exec w from .servers.SERVERS where procname in .feed.clusters, .dotz.liveh w;
   if[not count rdbHandles; .lg.e[`updateRDB;"no valid handles amongst subscribers"]; :()];
   tradedata:.trade.generateData[.feed.nq;.feed.nt;.feed.randomcounts];
   tradedata[`trades]:delete from tradedata[`trades] where null price;
@@ -48,7 +48,7 @@ timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push 
   };
 
 .trade.endofday:{
- rdbHandles:exec w from .servers.SERVERS where procname in .feed.clusters, not null w;
+ rdbHandles:exec w from .servers.SERVERS where procname in .feed.clusters, .dotz.liveh w;
  if[not count rdbHandles; .lg.e[`endofday;"no valid handles amongst subscribers. Try again later"]; :()];
  {[handle;dt] (neg first handle)(`.u.end;dt)}[;.proc.cd[]] each rdbHandles
   };

--- a/code/processes/tradeFeed.q
+++ b/code/processes/tradeFeed.q
@@ -52,6 +52,8 @@ timerperiod:@[value;`timerperiod;0D00:01:00.000];   //the time interval to push 
  {[handle;dt] (neg first handle)(`.u.end;dt)}[;.proc.cd[]] each rdbHandles
   };
 
+.servers.startup[];
+
 .timer.repeat[.proc.cp[];0Wp;.feed.timerperiod;(`.trade.updateRDB;`);"Publish Trade Feed"];
 
 .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.trade.endofday;`);0h;"Triggering RDB End of Day";1b];


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

- tradeFeed opens a new handle to the rdb on each update --> tradeFeed will use handles setup by the .servers namespace
- closed handle connections are automatically managed and re-established within the .servers namespace
- less untracked servers being opened between the rdb and feed in finspace

## Notes
- ``` .feed.clusters ``` should later include rdb2,rdb3,etc  