### PR TITLE
Rdb int partition

### DIFF
--- a/code/rdb/endofperiod.q
+++ b/code/rdb/endofperiod.q
@@ -7,6 +7,7 @@ endofperiod:{[currp;nextp;data]
 	times:.proc.starttimeUTC , @[;".proc.starttimeUTC";()]each h;
 	/-If we are the new process, exit function, do not want to close handle
 	if[.proc.starttimeUTC = max times;
+		.rdb.rdbpartition:`long$nextp;
 		/-Setting variables so rdb can become the active rdb for this new period
 		@[`.;`upd;:;.rdb.upd];
                 :()];

--- a/code/rdb/endofperiod.q
+++ b/code/rdb/endofperiod.q
@@ -7,8 +7,11 @@ endofperiod:{[currp;nextp;data]
 	times:.proc.starttimeUTC , @[;".proc.starttimeUTC";()]each h;
 	/-If we are the new process, exit function, do not want to close handle
 	if[.proc.starttimeUTC = max times;
-		.rdb.rdbpartition:`long$nextp;
 		/-Setting variables so rdb can become the active rdb for this new period
+		.rdb.rdbpartition:`long$nextp;
+		/-send message to gateways to update the rdb attributes
+		gateh:exec w from .servers.getservers[`proctype;.rdb.gatewaytypes;()!();0b;0b];
+                .async.send[0b;;(`setattributes;.proc.procname;.proc.proctype;.proc.getattributes[])] each neg[gateh];
 		@[`.;`upd;:;.rdb.upd];
                 :()];
 	/-We must be old process so unsubscribe from the tp and set upd to null

--- a/code/rdb/rdbstandard.q
+++ b/code/rdb/rdbstandard.q
@@ -1,3 +1,5 @@
-\d .
+//get the relevant rdb attributes (int partition)
+.proc.getattributes:{`int`tables!(.rdb.getpartition[],();tables[])}
 
+\d .
 upd:{[t;x]};


### PR DESCRIPTION
edit the end of period rdb function to update the partition to (long value of) next period (if new process) and send message to gateway to update attributes in servers table. Alter .proc.getattributes func in rdb to account for int partition.