### PR TITLE
Additional Permissions for terraform resources

### DIFF
--- a/terraform-deployment/deployments/main.tf
+++ b/terraform-deployment/deployments/main.tf
@@ -56,6 +56,7 @@ module "lambda" {
   environment-id       = module.environment.environment-id
   account_id           = module.environment.account_id
   s3-bucket-id         = module.environment.s3-bucket-id
+  s3-data-bucket-id    = module.environment.s3-data-bucket-id
   rdbCntr_mod          = var.rdbCntr_modulo
   send-sns-alert       = var.send-sns-alert
   alert-smpt-target    = var.alert-smpt-target

--- a/terraform-deployment/environment/main.tf
+++ b/terraform-deployment/environment/main.tf
@@ -112,7 +112,8 @@ data "aws_iam_policy_document" "s3-data-policy" {
     ]
     actions = [
       "s3:GetObject",
-      "s3:GetObjectTagging"
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion"
     ]
     principals {
       type        = "Service"
@@ -235,10 +236,12 @@ data "aws_iam_policy_document" "iam-policy" {
   statement {
     effect = "Allow"
     actions = [
-      "finspace:GetKxConnectionString"
+      "finspace:GetKxConnectionString",
+      "finspace:UpdateKxClusterDatabases"
     ]
     resources = [
-      "${aws_finspace_kx_environment.environment.arn}/kxCluster/*"
+      "${aws_finspace_kx_environment.environment.arn}/kxCluster/*",
+      "${aws_finspace_kx_environment.environment.arn}/kxDatabase/*/kxDataview/*"
     ]
   }
 
@@ -252,7 +255,9 @@ data "aws_iam_policy_document" "iam-policy" {
     ]
     resources = [
       "${aws_s3_bucket.finspace-code-bucket.arn}",
-      "${aws_s3_bucket.finspace-code-bucket.arn}/*"
+      "${aws_s3_bucket.finspace-code-bucket.arn}/*",
+      "${aws_s3_bucket.finspace-data-bucket.arn}",
+      "${aws_s3_bucket.finspace-data-bucket.arn}/*"
     ]
   }
 
@@ -362,6 +367,10 @@ output "database-name" {
 
 output "s3-bucket-id" {
   value = aws_s3_bucket.finspace-code-bucket.id
+}
+
+output "s3-data-bucket-id" {
+  value = aws_s3_bucket.finspace-data-bucket.id
 }
 
 output "s3-bucket-key" {

--- a/terraform-deployment/lambda/main.tf
+++ b/terraform-deployment/lambda/main.tf
@@ -20,6 +20,10 @@ variable "s3-bucket-id" {
   description = "name of code bucket"
 }
 
+variable "s3-data-bucket-id" {
+  description = "name of data bucket"
+}
+
 variable "rdbCntr_mod" {
   description = "maximum number of rdbs created by lambda"
 }
@@ -173,7 +177,9 @@ data "aws_iam_policy_document" "s3-permissions-lambda" {
 
     resources = [
       "arn:aws:s3:::${var.s3-bucket-id}",
-      "arn:aws:s3:::${var.s3-bucket-id}/*"
+      "arn:aws:s3:::${var.s3-bucket-id}/*",
+      "arn:aws:s3:::${var.s3-data-bucket-id}",
+      "arn:aws:s3:::${var.s3-data-bucket-id}/*"
     ]
   }
 }


### PR DESCRIPTION
## Author

eugene.temlock@dataintellect.com

## Summary

Need to keep permissions of our finspace exec roles, access policies of S3 buckets, and lambda exec roles to be in sync with permission requirements specified by AWS

## Fixes
- Add "s3:GetObjectVersion" permission to S3 data bucket access policy
- Adding permissions to update_kx_cluster_databases and access S3 data bucket to finspace exec role
- Adding permissions to access S3 data bucket to lambda exec role
