### PR TITLE
Update rdbstandard.q

### DIFF
--- a/code/rdb/rdbstandard.q
+++ b/code/rdb/rdbstandard.q
@@ -1,6 +1,3 @@
-//get the relevant rdb attributes (int partition)
-.proc.getattributes:{`int`tables!(.rdb.getpartition[],();tables[])}
-
 \d .
 
 upd:$[`daily~.finspace.rollovermode;


### PR DESCRIPTION
remove the attributes function overwrite as it no longer needs to be `int
torq declares partition type as `partition