### PR TITLE
Adding ../ to all image paths

### DIFF
--- a/docs/03-torqwithmanagedkdbinsights.md
+++ b/docs/03-torqwithmanagedkdbinsights.md
@@ -19,7 +19,7 @@ When porting TorQ to AWS we chose to make a minimum viable product and then buil
 These features allow us to store real-time and historical data and make it available to users.
 
 <p style="text-align: center">
-    <img src="graphics/architecture.png" alt="MVP Architecture" width="90%"/>
+    <img src="../graphics/architecture.png" alt="MVP Architecture" width="90%"/>
 </p>
 
 ## Notable Differences within this reduced version of TorQ in comparison to normal TorQ

--- a/docs/04-prerequisites.md
+++ b/docs/04-prerequisites.md
@@ -41,13 +41,13 @@ Choose the same AWS Region as your AWS Finspace KxEnvirnment
 Give your bucket a name
 
 <p style="text-align: center">
-    <img src="workshop/graphics/S3_general_configuration.png" alt="S3 general configurations" width="90%"/>
+    <img src="../workshop/graphics/S3_general_configuration.png" alt="S3 general configurations" width="90%"/>
 </p>
 
 Unselect the `Block all public access` box
 
 <p style="text-align: center">
-    <img src="workshop/graphics/S3_access_settings.png" alt="S3 Access Settings" width="90%"/>
+    <img src="../workshop/graphics/S3_access_settings.png" alt="S3 Access Settings" width="90%"/>
 </p>
 
 Leave all other settings as the default
@@ -57,7 +57,7 @@ Leave all other settings as the default
 Copy the ARN of your S3 buckets in the console by navigating to your S3 bucket, selecting `Properties`
 
 <p style="text-align: center">
-    <img src="workshop/graphics/S3_code_bucket_arn.png" alt="S3 Bucket Arn" width="90%"/>
+    <img src="../workshop/graphics/S3_code_bucket_arn.png" alt="S3 Bucket Arn" width="90%"/>
 </p>
 
 Edit the Access policy of both S3 buckets with the JSON document:

--- a/docs/05-terraform.md
+++ b/docs/05-terraform.md
@@ -16,7 +16,7 @@ This Terraform script can be used to deploy an entire environment from scratch. 
 It is split into two modules, one for the environment and one for the clusters. This makes the directory more organised and cluster deployments easier to manage. The cluster module is still dependent on the environment module as it will import some variables from here that are needed for cluster creation.
 
 <p style="text-align: center">
-    <img src="./workshop/graphics/terraform_modules.png" alt="Terraform Module Diagram" width="90%"/>
+    <img src="../workshop/graphics/terraform_modules.png" alt="Terraform Module Diagram" width="90%"/>
 </p>
 
 This Terraform setup is designed to deploy and manage a Managed kdb Insights environment running a TorQ bundle.

--- a/docs/05-terraform.md
+++ b/docs/05-terraform.md
@@ -16,7 +16,7 @@ This Terraform script can be used to deploy an entire environment from scratch. 
 It is split into two modules, one for the environment and one for the clusters. This makes the directory more organised and cluster deployments easier to manage. The cluster module is still dependent on the environment module as it will import some variables from here that are needed for cluster creation.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/terraform_modules.png" alt="Terraform Module Diagram" width="90%"/>
+    <img src="./workshop/graphics/terraform_modules.png" alt="Terraform Module Diagram" width="90%"/>
 </p>
 
 This Terraform setup is designed to deploy and manage a Managed kdb Insights environment running a TorQ bundle.

--- a/docs/06-scalinggroupandvolumecreation.md
+++ b/docs/06-scalinggroupandvolumecreation.md
@@ -13,7 +13,7 @@ To create a scaling group through the AWS Console, select your kdb environment a
     <img src="../workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="./workshop/graphics/scalinggroups_tab.png" alt="Scaling Group Tab" width="90%"/>
+    <img src="../workshop/graphics/scalinggroups_tab.png" alt="Scaling Group Tab" width="90%"/>
 </p>
 
 Click the `Create kdb scaling group` button
@@ -23,7 +23,7 @@ Click the `Create kdb scaling group` button
 3. Click the `Create kdb scaling group` button when you are happy with the settings.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_kdb_scaling_group.png" alt="Scaling Group Settings" width="90%"/>
+    <img src="../workshop/graphics/Create_kdb_scaling_group.png" alt="Scaling Group Settings" width="90%"/>
 </p>
 
 ## Shared Volume
@@ -31,7 +31,7 @@ Click the `Create kdb scaling group` button
 To create a shared volume through the AWS Console, select your kdb environment and navigate to the `Volumes` tab:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/volumes_tab.png" alt="Volumes Tab" width="90%"/>
+    <img src="../workshop/graphics/volumes_tab.png" alt="Volumes Tab" width="90%"/>
 </p>
 
 Click the `Create volume` button
@@ -42,14 +42,14 @@ Click the `Create volume` button
     - The size of allocated disk space must be at least 1200 GiB.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_shared_volume_pt1.png" alt="Volume Settings" width="90%"/>
+    <img src="../workshop/graphics/Create_shared_volume_pt1.png" alt="Volume Settings" width="90%"/>
 </p>
 
 1. Choose an Availability Zone. It is recommended that it matches with the Availability Zone you assigned the kdb scaling group to run on
 2. Click the `Create volume` button when you are happy with the settings
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_shared_volume_pt2.png" alt="Volume AZ Settings" width="90%"/>
+    <img src="../workshop/graphics/Create_shared_volume_pt2.png" alt="Volume AZ Settings" width="90%"/>
 </p>
 
 ## (Optional) Dataview 
@@ -61,7 +61,7 @@ If you plan to run your HDB cluster on a scaling group this step is required. Ot
 To create a scaling group through the AWS Console, select your kdb environment and navigate to the `Databases` tab:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
+    <img src="../workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
 </p>
 
 Select the database that has the changesets appropriate for your use case.
@@ -70,14 +70,14 @@ To learn more about changesets click [this link](https://docs.aws.amazon.com/fin
 1. Navigate to the `Dataview` tab and click the `Create dataview` button
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_dataview_pt0.png" alt="Dataview tab" width="90%"/>
+    <img src="../workshop/graphics/Create_dataview_pt0.png" alt="Dataview tab" width="90%"/>
 </p>
 
 1. Under `Dataview details` provide a `Name` for your dataview that is unique to your kdb environment
 2. Choose an Availability Zone. This must match the Availability Zone your kdb scaling group runs on
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_dataview_pt1.png" alt="Dataview Settings 1" width="90%"/>
+    <img src="../workshop/graphics/Create_dataview_pt1.png" alt="Dataview Settings 1" width="90%"/>
 </p>
 
 1. Under `Changeset update settings` you have the option of choosing two modes:
@@ -86,7 +86,7 @@ To learn more about changesets click [this link](https://docs.aws.amazon.com/fin
 2. Under `Segment configuration - optional` choose the root path for your `Database path` and the `Volume` you created in the prior step
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_dataview_pt2.png" alt="Dataview Settings 2" width="90%"/>
+    <img src="../workshop/graphics/Create_dataview_pt2.png" alt="Dataview Settings 2" width="90%"/>
 </p>
 
 Click `Create dataview` when you are happy with the settings

--- a/docs/06-scalinggroupandvolumecreation.md
+++ b/docs/06-scalinggroupandvolumecreation.md
@@ -10,10 +10,10 @@ Creating Kx Managed Insight Scaling Groups, Shared Volumes, and AWS Finspace Dat
 To create a scaling group through the AWS Console, select your kdb environment and navigate to the `Kdb scaling groups` tab:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
+    <img src="../workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="workshop/graphics/scalinggroups_tab.png" alt="Scaling Group Tab" width="90%"/>
+    <img src="./workshop/graphics/scalinggroups_tab.png" alt="Scaling Group Tab" width="90%"/>
 </p>
 
 Click the `Create kdb scaling group` button

--- a/docs/07-clustercreation.md
+++ b/docs/07-clustercreation.md
@@ -8,13 +8,13 @@ Creating TorQ Clusters
 To create a cluster, first select your kdb environment:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
+    <img src="../workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
 </p>
 
 Then select the `Clusters` tab, then either of the `Create cluster` buttons:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/create-cluster.png" alt="Create Cluster Button" width="90%"/>
+    <img src="../workshop/graphics/create-cluster.png" alt="Create Cluster Button" width="90%"/>
 </p>
 
 ## Prerequisites
@@ -37,25 +37,25 @@ For these clusters, you will require:
 3. Select the execution role for the [IAM user previously created](https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup). The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_details.png" alt="Discovery Cluster Details" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_details.png" alt="Discovery Cluster Details" width="90%"/>
     </p>
 
 4. Select `Run on kdb scaling group` for the Cluster running option.
    
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_running.png" alt="Discovery Cluster Running" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_running.png" alt="Discovery Cluster Running" width="90%"/>
     </p>
 
 5. Choose your group in the dropdown in the `Kdb scaling group details` section.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+        <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
     </p>
 
 6. In the `Node details` section, set the `Memory reservation per node` to the minimum allowed (6 MiB) and leave the rest blank.
     
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_memory_reservation.png" alt="Discovery Memory Reservation" width="90%"/>
+        <img src="../workshop/graphics/discovery_memory_reservation.png" alt="Discovery Memory Reservation" width="90%"/>
     </p>
 
 7. Leave Tags as empty and select `Next` to go to the next page.
@@ -64,11 +64,11 @@ For these clusters, you will require:
     - Alternatively, you can copy the URL from the codebucket itself.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/S3_bucket1.png" alt="Select your code bucket" width="90%"/>
+        <img src="../workshop/graphics/S3_bucket1.png" alt="Select your code bucket" width="90%"/>
     </p>
 
     <p style="text-align: center">
-        <img src="workshop/graphics/S3_bucket2.png" alt="Select your code file" width="90%"/>
+        <img src="../workshop/graphics/S3_bucket2.png" alt="Select your code file" width="90%"/>
     </p>
 
 9.  Enter `TorQ-Amazon-FinSpace-Starter-Pack/env.q` as your initialization script.
@@ -83,7 +83,7 @@ For these clusters, you will require:
     This specified initialization script and the command line arguments will set up the necessary environment for your cluster.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_add_code.png" alt="Discovery Add Code" width="90%"/>
+        <img src="../workshop/graphics/discovery_add_code.png" alt="Discovery Add Code" width="90%"/>
     </p>
 
 11. Select `Next` to go to the next page.
@@ -91,13 +91,13 @@ For these clusters, you will require:
 12. Select your previously created [VPC ID](https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html), [Subnets](https://docs.aws.amazon.com/vpc/latest/userguide/create-subnets.html), and Security Groups (we can use the readily available default), then select `Next` to go to the next page.
     
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_vpc.png" alt="Discovery VPC Settings" width="90%"/>
+        <img src="../workshop/graphics/discovery_vpc.png" alt="Discovery VPC Settings" width="90%"/>
     </p>
 
 13. Leave everything as blank and click `Next` to move on to the next page.
     
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_config_options.png" alt="Discovery Config Options" width="90%"/>
+        <img src="../workshop/graphics/discovery_config_options.png" alt="Discovery Config Options" width="90%"/>
     </p>
 14. Check the entered information in the review page, then select `Create cluster`.
 
@@ -109,7 +109,7 @@ For these clusters, you will require:
     - **Note:** This name must match your process name, `procname`, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. **Our suggestion is to use the process type** (`proctype`) **with a number** e.g. `tp1`.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/tp_cluster_details.png" alt="TP Cluster Details" width="90%"/>
+        <img src="../workshop/graphics/tp_cluster_details.png" alt="TP Cluster Details" width="90%"/>
     </p>
 
 3. Select the execution role for the [IAM user previously created](https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup). The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.
@@ -117,13 +117,13 @@ For these clusters, you will require:
 4. Select `Run on kdb scaling group` for the Cluster running option.
    
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_running.png" alt="TP Cluster Running" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_running.png" alt="TP Cluster Running" width="90%"/>
     </p>
 
 5. Choose your group in the dropdown in the `Kdb scaling group details` section.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+        <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
     </p>
 
 6. Enter a node count of "1". This will be the number of instances in a cluster. For the MVP only 1 is needed.
@@ -133,7 +133,7 @@ For these clusters, you will require:
 8. Leave Tags as empty and select `Next` to go to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_node_details.png" alt="TP Node Details" width="90%"/>
+        <img src="../workshop/graphics/rdb_node_details.png" alt="TP Node Details" width="90%"/>
     </p>
 
 9. Select `Browse S3`, search and select your codebucket and select your code.zip file.
@@ -151,7 +151,7 @@ For these clusters, you will require:
     This specified initialization script and the command line arguments will set up the necessary environment for your cluster.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/tp_add_code.png" alt="TP Add Code" width="90%"/>
+        <img src="../workshop/graphics/tp_add_code.png" alt="TP Add Code" width="90%"/>
     </p>
 
 12. Select `Next` to go to the next page.
@@ -161,7 +161,7 @@ For these clusters, you will require:
 14. Select your volume, then select `Next` to go to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/tp_log.png" alt="Add volume" width="90%"/>
+        <img src="../workshop/graphics/tp_log.png" alt="Add volume" width="90%"/>
     </p>
 
 15. Check the entered information in the review page, then select `Create cluster`.
@@ -174,7 +174,7 @@ For these clusters, you will require:
     - **Note:** This name must match your process name, `procname`, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. **Our suggestion is to use the process type** (`proctype`) **with a number** e.g. `rdb1`.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_cluster_details.png" alt="RDB Cluster Details" width="90%"/>
+        <img src="../workshop/graphics/rdb_cluster_details.png" alt="RDB Cluster Details" width="90%"/>
     </p>
 
 3. Select the execution role for the [IAM user previously created](https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup). The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.
@@ -182,13 +182,13 @@ For these clusters, you will require:
 4. Select `Run on kdb scaling group` for the Cluster running option.
    
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_running.png" alt="RDB Cluster Running" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_running.png" alt="RDB Cluster Running" width="90%"/>
     </p>
 
 5. Choose your group in the dropdown in the `Kdb scaling group details` section.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+        <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
     </p>
 
 6. Enter a node count of "1". This will be the number of instances in a cluster. For the MVP only 1 is needed.
@@ -198,7 +198,7 @@ For these clusters, you will require:
 8. Leave Tags as empty and select `Next` to go to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_node_details.png" alt="RDB Node Details" width="90%"/>
+        <img src="../workshop/graphics/rdb_node_details.png" alt="RDB Node Details" width="90%"/>
     </p>
 
 9. Select `Browse S3`, search and select your codebucket and select your code.zip file.
@@ -216,7 +216,7 @@ For these clusters, you will require:
     This specified initialization script and the command line arguments will set up the necessary environment for your cluster.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_add_code.png" alt="RDB Add Code" width="90%"/>
+        <img src="../workshop/graphics/rdb_add_code.png" alt="RDB Add Code" width="90%"/>
     </p>
 
 12. Select `Next` to go to the next page.
@@ -233,7 +233,7 @@ For these clusters, you will require:
 17. Select `Next` to go to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_config_options.png" alt="RDB Config Options" width="90%"/>
+        <img src="../workshop/graphics/rdb_config_options.png" alt="RDB Config Options" width="90%"/>
     </p>
 
 18. Check the entered information in the review page, then select `Create cluster`.
@@ -246,7 +246,7 @@ For these clusters, you will require:
     - **Note:** This name must match your process name, `procname`, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. **Our suggestion is to use the process type** (`proctype`) **with a number** e.g. `hdb1`.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/hdb_cluster_details.png" alt="HDB Cluster Details" width="90%"/>
+        <img src="../workshop/graphics/hdb_cluster_details.png" alt="HDB Cluster Details" width="90%"/>
     </p>
 
 3. Select the execution role for the [IAM user previously created](https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup). The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.
@@ -254,13 +254,13 @@ For these clusters, you will require:
 4. Select `Run on kdb scaling group` for the Cluster running option.
    
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_running.png" alt="HDB Cluster Running" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_running.png" alt="HDB Cluster Running" width="90%"/>
     </p>
 
 5. Choose your group in the dropdown in the `Kdb scaling group details` section.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+        <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
     </p>
 
 6. Enter a node count of "1". This will be the number of instances in a cluster. For the MVP only 1 is needed.
@@ -270,7 +270,7 @@ For these clusters, you will require:
 8. Leave Tags as empty and select `Next` to go to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_node_details.png" alt="HDB Node Details" width="90%"/>
+        <img src="../workshop/graphics/rdb_node_details.png" alt="HDB Node Details" width="90%"/>
     </p>
 
 9. Select `Browse S3`, search and select your codebucket and select your code.zip file.
@@ -288,7 +288,7 @@ For these clusters, you will require:
     This specified initialization script and the command line arguments will set up the necessary environment for your cluster.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/hdb_add_code.png" alt="HDB Add Code" width="90%"/>
+        <img src="../workshop/graphics/hdb_add_code.png" alt="HDB Add Code" width="90%"/>
     </p>
 
 12. Select `Next` to go to the next page.
@@ -302,7 +302,7 @@ For these clusters, you will require:
 16.  Select `Next` to go to the next page.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/hdb_config_options.png" alt="HDB Config Options" width="90%"/>
+    <img src="../workshop/graphics/hdb_config_options.png" alt="HDB Config Options" width="90%"/>
 </p>
 
 17. Check the entered information in the review page, then select `Create cluster`.
@@ -317,7 +317,7 @@ Ensure that the Discovery cluster is in a "Running" state before creating the Ga
     - **Note:** This name must match your process name, `procname`, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. **Our suggestion is to use the process type** (`proctype`) **with a number** e.g. `gateway1`.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/gw_cluster_details.png" alt="Gateway Cluster Details" width="90%"/>
+        <img src="../workshop/graphics/gw_cluster_details.png" alt="Gateway Cluster Details" width="90%"/>
     </p>
 
 3. Select the execution role for the [IAM user previously created](https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup). The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.
@@ -325,13 +325,13 @@ Ensure that the Discovery cluster is in a "Running" state before creating the Ga
 4. Select `Run on kdb scaling group` for the Cluster running option.
    
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_running.png" alt="Gateway Cluster Running" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_running.png" alt="Gateway Cluster Running" width="90%"/>
     </p>
 
 5. Choose your group in the dropdown in the `Kdb scaling group details` section.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+        <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
     </p>
 
 6. Enter a node count of "1". This will be the number of instances in a cluster. For the MVP only 1 is needed.
@@ -341,7 +341,7 @@ Ensure that the Discovery cluster is in a "Running" state before creating the Ga
 8. Leave Tags as empty and select `Next` to go to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/rdb_node_details.png" alt="Gateway Node Details" width="90%"/>
+        <img src="../workshop/graphics/rdb_node_details.png" alt="Gateway Node Details" width="90%"/>
     </p>
 
 9. Select `Browse S3`, search and select your codebucket and select your code.zip file.
@@ -359,7 +359,7 @@ Ensure that the Discovery cluster is in a "Running" state before creating the Ga
     This specified initialization script and the command line arguments will set up the necessary environment for your cluster.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/gw_add_code.png" alt="Gateway Add Code" width="90%"/>
+        <img src="../workshop/graphics/gw_add_code.png" alt="Gateway Add Code" width="90%"/>
     </p>
 
 12. Select `Next` to go to the next page.
@@ -379,7 +379,7 @@ Ensure that the RDB cluster is in a `Running` state before creating the Feed clu
 2. Choose a name for your cluster. As this is a sample feed and not a "production" intended process, please name it `feed1`.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/feed_cluster_details.png" alt="Feed Cluster Details" width="90%"/>
+        <img src="../workshop/graphics/feed_cluster_details.png" alt="Feed Cluster Details" width="90%"/>
     </p>
 
 3. Select the execution role for the [IAM user previously created](https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup). The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.
@@ -387,19 +387,19 @@ Ensure that the RDB cluster is in a `Running` state before creating the Feed clu
 4. Select `Run on kdb scaling group` for the Cluster running option.
    
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_cluster_running.png" alt="Feed Cluster Running" width="90%"/>
+        <img src="../workshop/graphics/discovery_cluster_running.png" alt="Feed Cluster Running" width="90%"/>
     </p>
 
 5. Choose your group in the dropdown in the `Kdb scaling group details` section.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+        <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
     </p>
 
 6. In the `Node details` section, set the `Memory reservation per node` to the minimum allowed (6 MiB) and leave the rest blank.
     
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_memory_reservation.png" alt="Feed Memory Reservation" width="90%"/>
+        <img src="../workshop/graphics/discovery_memory_reservation.png" alt="Feed Memory Reservation" width="90%"/>
     </p>
 
 7. Leave Tags as empty and select `Next` to go to the next page.
@@ -419,7 +419,7 @@ Ensure that the RDB cluster is in a `Running` state before creating the Feed clu
     This specified initialization script and the command line arguments will set up the necessary environment for your cluster.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/feed_add_code.png" alt="Feed Add Code" width="90%"/>
+        <img src="../workshop/graphics/feed_add_code.png" alt="Feed Add Code" width="90%"/>
     </p>
 
 11. Select `Next` to go to the next page.
@@ -429,7 +429,7 @@ Ensure that the RDB cluster is in a `Running` state before creating the Feed clu
 13. Leave everything as blank and click `Next` to move on to the next page.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/discovery_config_options.png" alt="Feed Config Options" width="90%"/>
+        <img src="../workshop/graphics/discovery_config_options.png" alt="Feed Config Options" width="90%"/>
     </p>
 
 14. Check the entered information in the review page, then select `Create cluster`.
@@ -447,7 +447,7 @@ When all clusters are up it should look like this:
 On cluster creation, most errors will result in your cluster going to a `Create failed` state.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/cluster_failure.png" alt="Cluster failure" width="90%"/>
+    <img src="../workshop/graphics/cluster_failure.png" alt="Cluster failure" width="90%"/>
 </p>
 
 If that is the case you should:
@@ -455,7 +455,7 @@ If that is the case you should:
 - Click the cluster name in the `Clusters` section of your environment.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/cluster_select.png" alt="Select Cluster" width="90%"/>
+        <img src="../workshop/graphics/cluster_select.png" alt="Select Cluster" width="90%"/>
     </p>
 
 - Scroll down the page and open the `Logs` tab. This should have a message with a more individualised error you can check.
@@ -463,7 +463,7 @@ If that is the case you should:
 - If you click the LogStream for an individual log it will take you to AWS CloudWatch where you can filter the messages for keywords or for messages in a certain time window.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/cluster_logs.png" alt="Select Cluster Logs" width="90%"/>
+        <img src="../workshop/graphics/cluster_logs.png" alt="Select Cluster Logs" width="90%"/>
     </p>
 
 It is worthwhile checking the logs even for clusters that have been created and searching for terms like `err`, `error` or `fail`.

--- a/docs/07-clustercreation.md
+++ b/docs/07-clustercreation.md
@@ -439,7 +439,7 @@ Ensure that the RDB cluster is in a `Running` state before creating the Feed clu
 When all clusters are up it should look like this:
 
 <p style="text-align: center">
-    <img src="graphics/clusters-running.png" alt="All Clusters Running" width="90%"/>
+    <img src="../graphics/clusters-running.png" alt="All Clusters Running" width="90%"/>
 </p>
 
 ## Errors in cluster creation

--- a/docs/08-createec2.md
+++ b/docs/08-createec2.md
@@ -6,13 +6,13 @@ Creating and Connect to an EC2 Instance
 Navigate to the EC2 service.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/navigate_ec2.png" alt="Navigate to the EC2 service" width="90%"/>
+    <img src="../workshop/graphics/navigate_ec2.png" alt="Navigate to the EC2 service" width="90%"/>
 </p>
 
 Select `Launch instance` to create a new EC2 instance.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_launch.png" alt="Select launch instance" width="90%"/>
+    <img src="../workshop/graphics/ec2_launch.png" alt="Select launch instance" width="90%"/>
 </p>
 
 Most options here can be left as their defaults. Here are the ones that need selected/changing:
@@ -20,26 +20,26 @@ Most options here can be left as their defaults. Here are the ones that need sel
 1. Select "Windows" from the `Quick Start` options.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/ec2_application.png" alt="Select windows quick start" width="90%"/>
+        <img src="../workshop/graphics/ec2_application.png" alt="Select windows quick start" width="90%"/>
     </p>
 
 2. We need to create a new key pair: Select `Create new key pair`.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/ec2_keypair_button.png" alt="Select create new key pair" width="90%"/>
+        <img src="../workshop/graphics/ec2_keypair_button.png" alt="Select create new key pair" width="90%"/>
     </p>
 
 3. Enter a name for your key pair, leave the key pair type as `RSA` and the file format as `.pem`. This will download a key file to you PC which you will use to connect to the instance.
 
     <p style="text-align: center">
-        <img src="workshop/graphics/create_key_pair.png" alt="Create new key pair" width="90%"/>
+        <img src="../workshop/graphics/create_key_pair.png" alt="Create new key pair" width="90%"/>
     </p>
 
 The network should be in the same VPC as your cluster. Select `Create security group` that allows Remote Desktop Protocol (RDP) connections from anywhere.
     - This is only for the purposes of the MVP. For customising see [this page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html) on security groups.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_network.png" alt="EC2 network" width="90%"/>
+    <img src="../workshop/graphics/ec2_network.png" alt="EC2 network" width="90%"/>
 </p>
 
 ## Adding your new security group to you EC2
@@ -49,37 +49,37 @@ Now we need to add the security group of your cluster to your EC2.
 Navigate to EC2 service.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_navigate.png" alt="Navigate to EC2" width="90%"/>
+    <img src="../workshop/graphics/ec2_navigate.png" alt="Navigate to EC2" width="90%"/>
 </p>
 
 Select `Instances (running)`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_navigate2.png" alt="Select Instance running" width="90%"/>
+    <img src="../workshop/graphics/ec2_navigate2.png" alt="Select Instance running" width="90%"/>
 </p>
 
 Open your EC2 Instance.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
 </p>
 
 Select `Actions` -> `Security` -> `Change security groups`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_add_security.png" alt="Select change security groups" width="90%"/>
+    <img src="../workshop/graphics/ec2_add_security.png" alt="Select change security groups" width="90%"/>
 </p>
 
 Search and select the security group that is on your clusters, select `Add security group` then `Save`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_add_security2.png" alt="Add security group" width="90%"/>
+    <img src="../workshop/graphics/ec2_add_security2.png" alt="Add security group" width="90%"/>
 </p>
 
 You should now have two security groups, one from the launch wizard, and the one you added manually that is also attached to your clusters.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_security.png" alt="Security group example" width="90%"/>
+    <img src="../workshop/graphics/ec2_security.png" alt="Security group example" width="90%"/>
 </p>
 
 ## Connecting to your EC2 Instance
@@ -87,13 +87,13 @@ You should now have two security groups, one from the launch wizard, and the one
 Open your EC2 Instance.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
 </p>
 
 Select `Connect`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect2.png" alt="Select connect" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect2.png" alt="Select connect" width="90%"/>
 </p>
 
 ### Get your password
@@ -103,13 +103,13 @@ This only needs to be done once. Once you have this password you can skip this s
 Select `Get password`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect3.png" alt="Get password" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect3.png" alt="Get password" width="90%"/>
 </p>
 
 Upload the `.pem` that was saved to you PC earlier (alternativly you can just paste the contents of this file in the text box).
 
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect4.png" alt="Upload .pem file" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect4.png" alt="Upload .pem file" width="90%"/>
 </p>
 
 This will return the value of your password. Keep a note of this password as you will need it to connect your EC2.
@@ -119,7 +119,7 @@ This will return the value of your password. Keep a note of this password as you
 Download the remote desktop file.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect5.png" alt="Dowload remote desktop file" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect5.png" alt="Dowload remote desktop file" width="90%"/>
 </p>
 
 Run this file and enter the password you recieved above when promted. You should now be connected to the Windows remote desktop.

--- a/docs/09-clusterconnectionstring.md
+++ b/docs/09-clusterconnectionstring.md
@@ -90,13 +90,13 @@ Your Trust relationship should have at least these:
 In your kdb environment, go to the `Users` tab and select `Add user`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/create_user_button.png" alt="Create user button" width="90%"/>
+    <img src="../workshop/graphics/create_user_button.png" alt="Create user button" width="90%"/>
 </p>
 
 Give it a name and select the `IAM role` you created above.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/create_user.png" alt="Add user" width="90%"/>
+    <img src="../workshop/graphics/create_user.png" alt="Add user" width="90%"/>
 </p>
 
 ## Generate Connection String
@@ -104,13 +104,13 @@ Give it a name and select the `IAM role` you created above.
 On the `Users` tab, copy the links for `IAM role` and `User ARN` for the user.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/user_details.png" alt="User details" width="90%"/>
+    <img src="../workshop/graphics/user_details.png" alt="User details" width="90%"/>
 </p>
 
 Navigate to `CloudShell`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/cloudshell.png" alt="Navigate to CloudShell" width="90%"/>
+    <img src="../workshop/graphics/cloudshell.png" alt="Navigate to CloudShell" width="90%"/>
 </p>
 
 Replace `<ARN_COPIED_FROM_ABOVE>` with the `IAM Role` copied above and run the following (this will not return anything):
@@ -127,7 +127,7 @@ This lets you assume the role that you have just created by taking the values re
 Copy your kdb Environment ID:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/kdbenv_id.png" alt="Get you kdb env ID" width="90%"/>
+    <img src="../workshop/graphics/kdbenv_id.png" alt="Get you kdb env ID" width="90%"/>
 </p>
 
 Replace `<YOUR_KDB_ENVIRONMENT_ID>` with your kdb environment ID, `<USER_ARN_COPIED_ABOVE>` with the `User ARN`, and `<NAME_OF_CLUSTER>` with the name of the cluster you want to connect to. Run the following:
@@ -137,5 +137,5 @@ Replace `<YOUR_KDB_ENVIRONMENT_ID>` with your kdb environment ID, `<USER_ARN_COP
 This will return a large connection string which can be used to connect to your cluster.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/connection_string.png" alt="Connection string example" width="90%"/>
+    <img src="../workshop/graphics/connection_string.png" alt="Connection string example" width="90%"/>
 </p>

--- a/docs/10-setupqStudio.md
+++ b/docs/10-setupqStudio.md
@@ -8,19 +8,19 @@ You must follow these steps from within your EC2 instance.
 Navigate to the [TimeStored](https://www.timestored.com/qstudio/download) website and download the relavent version (usually x64).
 
 <p style="text-align: center">
-    <img src="workshop/graphics/qStudio_Download1.png" alt="Download button on qStudio website" width="90%"/>
+    <img src="../workshop/graphics/qStudio_Download1.png" alt="Download button on qStudio website" width="90%"/>
 </p>
 
 Download the [Microsoft C++ 2010 service pack](https://www.microsoft.com/en-gb/download/details.aspx?id=26999) (there is a specific DLL from this that you need that is usually installed on Windows machines).
 
 <p style="text-align: center">
-    <img src="workshop/graphics/MSpack_download.png" alt="Download MSPack" width="90%"/>
+    <img src="../workshop/graphics/MSpack_download.png" alt="Download MSPack" width="90%"/>
 </p>
 
 Select the relevant version (usually x64).**
 
 <p style="text-align: center">
-    <img src="workshop/graphics/MSpack_download2.png" alt="Download MSPack select version" width="90%"/>
+    <img src="../workshop/graphics/MSpack_download2.png" alt="Download MSPack select version" width="90%"/>
 </p>
 
 Run the file that was just downloaded.
@@ -28,11 +28,11 @@ Run the file that was just downloaded.
 Search for ‘Edit Environment variables’ and add `SSL_VERIFY_SERVER=NO` as one of them.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/edit_env_var1.png" alt="Edit Environment Variables 1" width="90%"/>
+    <img src="../workshop/graphics/edit_env_var1.png" alt="Edit Environment Variables 1" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="workshop/graphics/edit_env_var2.png" alt="Edit Environment Variables 2" width="90%"/>
+    <img src="../workshop/graphics/edit_env_var2.png" alt="Edit Environment Variables 2" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="workshop/graphics/edit_env_var3.png" alt="Edit Environment Variables 3" width="90%"/>
+    <img src="../workshop/graphics/edit_env_var3.png" alt="Edit Environment Variables 3" width="90%"/>
 </p>

--- a/docs/11-connectingusingqStudio.md
+++ b/docs/11-connectingusingqStudio.md
@@ -4,19 +4,19 @@ Connecting Using qStudio
 Open qStudio, right-click on `Servers` in the top left corner and select `Add Server`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Servers_qStudio1.png" alt="Add Server Connection" width="90%"/>
+    <img src="../workshop/graphics/Servers_qStudio1.png" alt="Add Server Connection" width="90%"/>
 </p>
 
 You will then see a pop-up showing the server properties. This is where you will add the information from the connection string (details below in the next step).
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Server_Properties1.png" alt="Server Properties" width="90%"/>
+    <img src="../workshop/graphics/Server_Properties1.png" alt="Server Properties" width="90%"/>
 </p>
 
 Follow the step in our [Generate Connection String section](https://dataintellecttech.github.io/TorQ-Amazon-FinSpace-Starter-Pack/08-clusterconnectionstring/#generate-connection-string) to get a fresh connection string. The generated connection string provides you with everything you need to fill the boxes above. See the below connection string for an example:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Connectionstring3.png" alt="Connection String" width="90%"/>
+    <img src="../workshop/graphics/Connectionstring3.png" alt="Connection String" width="90%"/>
 </p>
 
 The required fields in the Server Properties screen are contained within the connection string and are colon separated. Here,
@@ -32,5 +32,5 @@ The required fields in the Server Properties screen are contained within the con
 `Password:` Host=vpce-063d07d253dde398d-19p5nh4w.vpce-svc-0b408455b16d79292.us-west-2.vpce.amazonaws.com&Port=443&User=david-finspace&Action=finspace%3AConnectKxCluster&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDUaCXVzLXdlc3QtMiJGMEQCIFOmCCIAE5hyh0obtgV8TeS9jCglbxFPEossH5f4vRhrAiAIaxSHF%2FQhjqACSlmwlLTNJBvx658bQwyiH9LVz20ehSr4AgguEAIaDDc2NjAxMjI4NjAwMyIMl3TMLJjQytFtFLaiKtUCbJrjypNOC5U8GwttcBfln2SV%2FJclct%2FmeDtnUCUcVB3bzcCUOpGQFXUR%2FtonWVO0ZO1SUu%2Bna%2Bs0l0UfMu7K7qDOQhszg1%2Fxdblx0TRi70GVunATeJlpppyQeZNUk9RHSOvGPCN8VKGBJmisbeo3bJb7MvVLak1lgVdLn%2FxUIS0uTfA62PbzU6LPE1nj85bupgLrvAMlSwvZMy3pVXJaN%2BBvk0mulmCvIYfqlqL%2FcjvWbOMQdyXsdAYCO4TRpA7I38Jmfr9h1oee2JVvVMCu41yRQhbAqtqgvNwrhgSyOQASAJSVGiIPHiXyGz5KefntOfq1zADleUrUg0Nvh6EPFj%2FavNsHZyBSapvUVVsx%2FA9aI2aHeg5P%2FtCifq%2Bnxg5vyKSX4GcB7P40pKs3Ymeb3yAUllN2tJ5VXlx7SI3p8jfTB8k72BeOzu%2BLbWs5gtb%2BlZG1cSQwzKSHrwY6wAEpzwyEjjuh50PM6OZgRBNgBEOiqLaTHqjBv7VHcjsF5FnpJqZ2AhBtQXXkFiItA%2FSZ7B0aGbL0sYJ8v7WZZIMtAvg4e0ve9VBYXf4hnl5i82T5EJfAy727E9e25Wwb%2FILZAeOjdTY0IhcgvWlLCeBJNEHEMO8h8yupkLfFQHlNvF14wrH1U8bSd934M8k%2F22%2FDTrZFlVQXe%2FeLYt%2FxOBEHfHWiMH51v2IDv39%2B%2B7%2FGq3XmrcNymPQQ0HcoJEK%2BTjg%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240301T130412Z&X-Amz-SignedHeaders=host&X-Amz-Expires=900&X-Amz-Credential=ASIA3EWPD4QZXLHMX4GY%2F20240301%2Fus-west-2%2Ffinspace-apricot%2Faws4_request&X-Amz-Signature=c134f0dc1f0cba738c0bf8547c9ca8702593ea9e9b89ee2d17892fd379524d30
 
 <p style="text-align: center">
-    <img src="workshop/graphics/CompleteServers1.png" alt="All Servers" width="90%"/>
+    <img src="../workshop/graphics/CompleteServers1.png" alt="All Servers" width="90%"/>
 </p>

--- a/docs/12-runningqueries.md
+++ b/docs/12-runningqueries.md
@@ -8,13 +8,13 @@ For queries to be ran through the gateway, we must update some preferences on qS
 We will need to uncheck the box labelled `Wrap query sent to server`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/Preferences2.png" alt="Preferences" width="90%"/>
+    <img src="../workshop/graphics/Preferences2.png" alt="Preferences" width="90%"/>
 </p>
 
 The queries below should then all run successfully!
 
 <p style="text-align: center">
-    <img src="workshop/graphics/RunningQueries.png" alt="qStudio Queries" width="90%"/>
+    <img src="../workshop/graphics/RunningQueries.png" alt="qStudio Queries" width="90%"/>
 </p>
 
 Example queries are listed below:

--- a/docs/13-healthcheck.md
+++ b/docs/13-healthcheck.md
@@ -6,7 +6,7 @@ Check your system is healthy
 Below is an example of what running clusters look like. You can find this page by going to the AWS Console -> `Amazon FinSpace` -> `Kdb environments` -> Select your environment -> `Clusters`
 
 <p style="text-align: center">
-    <img src="graphics/clusters-running.png" alt="Clusters running example image" width="90%"/>
+    <img src="../graphics/clusters-running.png" alt="Clusters running example image" width="90%"/>
 </p>
 
 ## Run some queries

--- a/docs/14-takingitdown.md
+++ b/docs/14-takingitdown.md
@@ -6,13 +6,13 @@ Taking it Down
 From your Kdb environment select the cluster you want to delete and select `Delete`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_cluster1.png" alt="Select delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_cluster1.png" alt="Select delete cluster" width="90%"/>
 </p>
 
 On the confirmation dialog box, enter confirm then select `Delete`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_cluster2.png" alt="Delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_cluster2.png" alt="Delete cluster" width="90%"/>
 </p>
 
 ## Deleting your dataview
@@ -21,20 +21,20 @@ On the confirmation dialog box, enter confirm then select `Delete`.
 1. Select your kdb environment and navigate to the `Databases` tab. Then select the database your dataview is associated with:
 
 <p style="text-align: center">
-    <img src="workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
+    <img src="../workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
 </p>
 
 1. Navigate to the `Dataviews` tab. Select the circular button to the left of the dataview you want to delete. 
 2. Click the `Delete` button
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_dataview.png" alt="Delete Dataview" width="90%"/>
+    <img src="../workshop/graphics/delete_dataview.png" alt="Delete Dataview" width="90%"/>
 </p>
 
 1. On the confirmation dialog box, type "confirm" and then click the `Delete` button.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/confirm_delete_dataview.png" alt="Delete Dataview confirm" width="90%"/>
+    <img src="../workshop/graphics/confirm_delete_dataview.png" alt="Delete Dataview confirm" width="90%"/>
 </p>
 
 ## Deleting your Shared Volume
@@ -42,13 +42,13 @@ On the confirmation dialog box, enter confirm then select `Delete`.
 1. Select your kdb environment and navigate to the `Volumes` tab. Then select the volume you like to delete and click `Delete`
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_volume.png" alt="Delete Volume" width="90%"/>
+    <img src="../workshop/graphics/delete_volume.png" alt="Delete Volume" width="90%"/>
 </p>
 
 1. On the confirmation dialog box, type "confirm" and then click the `Delete` button.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/confirm_delete_volume.png" alt="Delete Volume confirm" width="90%"/>
+    <img src="../workshop/graphics/confirm_delete_volume.png" alt="Delete Volume confirm" width="90%"/>
 </p>
 
 ## Deleting your Kdb Scaling Group
@@ -57,13 +57,13 @@ On the confirmation dialog box, enter confirm then select `Delete`.
 1. Select your kdb environment and navigate to the `Kdb scaling groups` tab. Then select the scaling group you like to delete and click `Delete`
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_scaling_groups.png" alt="Delete Scaling Group" width="90%"/>
+    <img src="../workshop/graphics/delete_scaling_groups.png" alt="Delete Scaling Group" width="90%"/>
 </p>
 
 1. On the confirmation dialog box, type "confirm" and then click the `Delete` button.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/confirm_delete_scaling_groups.png" alt="Delete Scaling Group confirm" width="90%"/>
+    <img src="../workshop/graphics/confirm_delete_scaling_groups.png" alt="Delete Scaling Group confirm" width="90%"/>
 </p>
 
 ## Deleting your database 
@@ -71,11 +71,11 @@ On the confirmation dialog box, enter confirm then select `Delete`.
 From your Kdb environment select the `Databases` tab, select the database you want to delete and select `Delete`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_database1.png" alt="Delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_database1.png" alt="Delete cluster" width="90%"/>
 </p>
 
 On the confirmation dialog box, enter confirm then select `Delete`.
 
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_database2.png" alt="Delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_database2.png" alt="Delete cluster" width="90%"/>
 </p>


### PR DESCRIPTION
So the images are broken because the paths are wrong after being deployed, here's an example:

The actual path for an image on page 5 is this: https://dataintellecttech.github.io/TorQ-Amazon-FinSpace-Starter-Pack/workshop/graphics/terraform_modules.png
But the link that is present on the page is this: https://dataintellecttech.github.io/TorQ-Amazon-FinSpace-Starter-Pack/05-terraform/workshop/graphics/terraform_modules.png

The different between the broken and good path is that the broken path has `/05-terraform/` in the path.
This is not present in the github view, only in the pages website, which is why it appears to break.

This is because in the build process for gh-pages, a subdir for all pages are created which invalidates the hardcoded image paths.
I have tried adding  `../` to the paths to try fix this.