### PR TITLE
Adding ../ to all image paths

### DIFF
--- a/04-prerequisites/index.html
+++ b/04-prerequisites/index.html
@@ -854,19 +854,19 @@
 <p>Choose the same AWS Region as your AWS Finspace KxEnvirnment</p>
 <p>Give your bucket a name</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/S3_general_configuration.png" alt="S3 general configurations" width="90%"/>
+    <img src="../workshop/graphics/S3_general_configuration.png" alt="S3 general configurations" width="90%"/>
 </p>
 
 <p>Unselect the <code>Block all public access</code> box</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/S3_access_settings.png" alt="S3 Access Settings" width="90%"/>
+    <img src="../workshop/graphics/S3_access_settings.png" alt="S3 Access Settings" width="90%"/>
 </p>
 
 <p>Leave all other settings as the default</p>
 <h3 id="edit-the-access-policy">Edit the access policy</h3>
 <p>Copy the ARN of your S3 buckets in the console by navigating to your S3 bucket, selecting <code>Properties</code></p>
 <p style="text-align: center">
-    <img src="workshop/graphics/S3_code_bucket_arn.png" alt="S3 Bucket Arn" width="90%"/>
+    <img src="../workshop/graphics/S3_code_bucket_arn.png" alt="S3 Bucket Arn" width="90%"/>
 </p>
 
 <p>Edit the Access policy of both S3 buckets with the JSON document:</p>

--- a/05-terraform/index.html
+++ b/05-terraform/index.html
@@ -929,7 +929,7 @@
 </ul>
 <p>It is split into two modules, one for the environment and one for the clusters. This makes the directory more organised and cluster deployments easier to manage. The cluster module is still dependent on the environment module as it will import some variables from here that are needed for cluster creation.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/terraform_modules.png" alt="Terraform Module Diagram" width="90%"/>
+    <img src="../workshop/graphics/terraform_modules.png" alt="Terraform Module Diagram" width="90%"/>
 </p>
 
 <p>This Terraform setup is designed to deploy and manage a Managed kdb Insights environment running a TorQ bundle.</p>

--- a/06-scalinggroupandvolumecreation/index.html
+++ b/06-scalinggroupandvolumecreation/index.html
@@ -718,10 +718,10 @@
 <h2 id="scaling-groups">Scaling Groups</h2>
 <p>To create a scaling group through the AWS Console, select your kdb environment and navigate to the <code>Kdb scaling groups</code> tab:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
+    <img src="../workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="workshop/graphics/scalinggroups_tab.png" alt="Scaling Group Tab" width="90%"/>
+    <img src="../workshop/graphics/scalinggroups_tab.png" alt="Scaling Group Tab" width="90%"/>
 </p>
 
 <p>Click the <code>Create kdb scaling group</code> button</p>
@@ -731,13 +731,13 @@
 <li>Click the <code>Create kdb scaling group</code> button when you are happy with the settings.</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_kdb_scaling_group.png" alt="Scaling Group Settings" width="90%"/>
+    <img src="../workshop/graphics/Create_kdb_scaling_group.png" alt="Scaling Group Settings" width="90%"/>
 </p>
 
 <h2 id="shared-volume">Shared Volume</h2>
 <p>To create a shared volume through the AWS Console, select your kdb environment and navigate to the <code>Volumes</code> tab:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/volumes_tab.png" alt="Volumes Tab" width="90%"/>
+    <img src="../workshop/graphics/volumes_tab.png" alt="Volumes Tab" width="90%"/>
 </p>
 
 <p>Click the <code>Create volume</code> button</p>
@@ -750,7 +750,7 @@
 </li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_shared_volume_pt1.png" alt="Volume Settings" width="90%"/>
+    <img src="../workshop/graphics/Create_shared_volume_pt1.png" alt="Volume Settings" width="90%"/>
 </p>
 
 <ol>
@@ -758,7 +758,7 @@
 <li>Click the <code>Create volume</code> button when you are happy with the settings</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_shared_volume_pt2.png" alt="Volume AZ Settings" width="90%"/>
+    <img src="../workshop/graphics/Create_shared_volume_pt2.png" alt="Volume AZ Settings" width="90%"/>
 </p>
 
 <h2 id="optional-dataview">(Optional) Dataview</h2>
@@ -766,7 +766,7 @@
 <p>If you plan to run your HDB cluster on a scaling group this step is required. Otherwise, this step is optional.</p>
 <p>To create a scaling group through the AWS Console, select your kdb environment and navigate to the <code>Databases</code> tab:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
+    <img src="../workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
 </p>
 
 <p>Select the database that has the changesets appropriate for your use case.
@@ -775,7 +775,7 @@ To learn more about changesets click <a href="https://docs.aws.amazon.com/finspa
 <li>Navigate to the <code>Dataview</code> tab and click the <code>Create dataview</code> button</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_dataview_pt0.png" alt="Dataview tab" width="90%"/>
+    <img src="../workshop/graphics/Create_dataview_pt0.png" alt="Dataview tab" width="90%"/>
 </p>
 
 <ol>
@@ -783,7 +783,7 @@ To learn more about changesets click <a href="https://docs.aws.amazon.com/finspa
 <li>Choose an Availability Zone. This must match the Availability Zone your kdb scaling group runs on</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_dataview_pt1.png" alt="Dataview Settings 1" width="90%"/>
+    <img src="../workshop/graphics/Create_dataview_pt1.png" alt="Dataview Settings 1" width="90%"/>
 </p>
 
 <ol>
@@ -795,7 +795,7 @@ To learn more about changesets click <a href="https://docs.aws.amazon.com/finspa
 <li>Under <code>Segment configuration - optional</code> choose the root path for your <code>Database path</code> and the <code>Volume</code> you created in the prior step</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/Create_dataview_pt2.png" alt="Dataview Settings 2" width="90%"/>
+    <img src="../workshop/graphics/Create_dataview_pt2.png" alt="Dataview Settings 2" width="90%"/>
 </p>
 
 <p>Click <code>Create dataview</code> when you are happy with the settings</p>

--- a/07-clustercreation/index.html
+++ b/07-clustercreation/index.html
@@ -825,12 +825,12 @@
 <hr />
 <p>To create a cluster, first select your kdb environment:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
+    <img src="../workshop/graphics/kdbenv.png" alt="Select kdb env" width="90%"/>
 </p>
 
 <p>Then select the <code>Clusters</code> tab, then either of the <code>Create cluster</code> buttons:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/create-cluster.png" alt="Create Cluster Button" width="90%"/>
+    <img src="../workshop/graphics/create-cluster.png" alt="Create Cluster Button" width="90%"/>
 </p>
 
 <h2 id="prerequisites">Prerequisites</h2>
@@ -856,25 +856,25 @@
 <li>
 <p>Select the execution role for the <a href="https://catalog.us-east-1.prod.workshops.aws/workshops/a1575309-1f43-4945-a5fa-a4d62d5e821d/en-US/rolesetup">IAM user previously created</a>. The user for all 6 clusters should be the same. This is so that each cluster has the correct permissions.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_details.png" alt="Discovery Cluster Details" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_details.png" alt="Discovery Cluster Details" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Select <code>Run on kdb scaling group</code> for the Cluster running option.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_running.png" alt="Discovery Cluster Running" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_running.png" alt="Discovery Cluster Running" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Choose your group in the dropdown in the <code>Kdb scaling group details</code> section.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+    <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>In the <code>Node details</code> section, set the <code>Memory reservation per node</code> to the minimum allowed (6 MiB) and leave the rest blank.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_memory_reservation.png" alt="Discovery Memory Reservation" width="90%"/>
+    <img src="../workshop/graphics/discovery_memory_reservation.png" alt="Discovery Memory Reservation" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -886,10 +886,10 @@
 <li>Alternatively, you can copy the URL from the codebucket itself.</li>
 </ul>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/S3_bucket1.png" alt="Select your code bucket" width="90%"/>
+    <img src="../workshop/graphics/S3_bucket1.png" alt="Select your code bucket" width="90%"/>
 </p></p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/S3_bucket2.png" alt="Select your code file" width="90%"/>
+    <img src="../workshop/graphics/S3_bucket2.png" alt="Select your code file" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -917,7 +917,7 @@
 </table>
 <p>This specified initialization script and the command line arguments will set up the necessary environment for your cluster.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_add_code.png" alt="Discovery Add Code" width="90%"/>
+    <img src="../workshop/graphics/discovery_add_code.png" alt="Discovery Add Code" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -926,13 +926,13 @@
 <li>
 <p>Select your previously created <a href="https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html">VPC ID</a>, <a href="https://docs.aws.amazon.com/vpc/latest/userguide/create-subnets.html">Subnets</a>, and Security Groups (we can use the readily available default), then select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_vpc.png" alt="Discovery VPC Settings" width="90%"/>
+    <img src="../workshop/graphics/discovery_vpc.png" alt="Discovery VPC Settings" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Leave everything as blank and click <code>Next</code> to move on to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_config_options.png" alt="Discovery Config Options" width="90%"/>
+    <img src="../workshop/graphics/discovery_config_options.png" alt="Discovery Config Options" width="90%"/>
 </p>
 14. Check the entered information in the review page, then select <code>Create cluster</code>.</p>
 </li>
@@ -948,7 +948,7 @@
 <li><strong>Note:</strong> This name must match your process name, <code>procname</code>, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. <strong>Our suggestion is to use the process type</strong> (<code>proctype</code>) <strong>with a number</strong> e.g. <code>tp1</code>.</li>
 </ul>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/tp_cluster_details.png" alt="TP Cluster Details" width="90%"/>
+    <img src="../workshop/graphics/tp_cluster_details.png" alt="TP Cluster Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -957,13 +957,13 @@
 <li>
 <p>Select <code>Run on kdb scaling group</code> for the Cluster running option.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_running.png" alt="TP Cluster Running" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_running.png" alt="TP Cluster Running" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Choose your group in the dropdown in the <code>Kdb scaling group details</code> section.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+    <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -975,7 +975,7 @@
 <li>
 <p>Leave Tags as empty and select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_node_details.png" alt="TP Node Details" width="90%"/>
+    <img src="../workshop/graphics/rdb_node_details.png" alt="TP Node Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1009,7 +1009,7 @@
 </table>
 <p>This specified initialization script and the command line arguments will set up the necessary environment for your cluster.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/tp_add_code.png" alt="TP Add Code" width="90%"/>
+    <img src="../workshop/graphics/tp_add_code.png" alt="TP Add Code" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1021,7 +1021,7 @@
 <li>
 <p>Select your volume, then select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/tp_log.png" alt="Add volume" width="90%"/>
+    <img src="../workshop/graphics/tp_log.png" alt="Add volume" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1039,7 +1039,7 @@
 <li><strong>Note:</strong> This name must match your process name, <code>procname</code>, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. <strong>Our suggestion is to use the process type</strong> (<code>proctype</code>) <strong>with a number</strong> e.g. <code>rdb1</code>.</li>
 </ul>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_cluster_details.png" alt="RDB Cluster Details" width="90%"/>
+    <img src="../workshop/graphics/rdb_cluster_details.png" alt="RDB Cluster Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1048,13 +1048,13 @@
 <li>
 <p>Select <code>Run on kdb scaling group</code> for the Cluster running option.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_running.png" alt="RDB Cluster Running" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_running.png" alt="RDB Cluster Running" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Choose your group in the dropdown in the <code>Kdb scaling group details</code> section.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+    <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1066,7 +1066,7 @@
 <li>
 <p>Leave Tags as empty and select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_node_details.png" alt="RDB Node Details" width="90%"/>
+    <img src="../workshop/graphics/rdb_node_details.png" alt="RDB Node Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1100,7 +1100,7 @@
 </table>
 <p>This specified initialization script and the command line arguments will set up the necessary environment for your cluster.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_add_code.png" alt="RDB Add Code" width="90%"/>
+    <img src="../workshop/graphics/rdb_add_code.png" alt="RDB Add Code" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1124,7 +1124,7 @@
 <li>
 <p>Select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_config_options.png" alt="RDB Config Options" width="90%"/>
+    <img src="../workshop/graphics/rdb_config_options.png" alt="RDB Config Options" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1142,7 +1142,7 @@
 <li><strong>Note:</strong> This name must match your process name, <code>procname</code>, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. <strong>Our suggestion is to use the process type</strong> (<code>proctype</code>) <strong>with a number</strong> e.g. <code>hdb1</code>.</li>
 </ul>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/hdb_cluster_details.png" alt="HDB Cluster Details" width="90%"/>
+    <img src="../workshop/graphics/hdb_cluster_details.png" alt="HDB Cluster Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1151,13 +1151,13 @@
 <li>
 <p>Select <code>Run on kdb scaling group</code> for the Cluster running option.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_running.png" alt="HDB Cluster Running" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_running.png" alt="HDB Cluster Running" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Choose your group in the dropdown in the <code>Kdb scaling group details</code> section.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+    <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1169,7 +1169,7 @@
 <li>
 <p>Leave Tags as empty and select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_node_details.png" alt="HDB Node Details" width="90%"/>
+    <img src="../workshop/graphics/rdb_node_details.png" alt="HDB Node Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1203,7 +1203,7 @@
 </table>
 <p>This specified initialization script and the command line arguments will set up the necessary environment for your cluster.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/hdb_add_code.png" alt="HDB Add Code" width="90%"/>
+    <img src="../workshop/graphics/hdb_add_code.png" alt="HDB Add Code" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1223,7 +1223,7 @@
 </li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/hdb_config_options.png" alt="HDB Config Options" width="90%"/>
+    <img src="../workshop/graphics/hdb_config_options.png" alt="HDB Config Options" width="90%"/>
 </p>
 
 <ol>
@@ -1241,7 +1241,7 @@
 <li><strong>Note:</strong> This name must match your process name, <code>procname</code>, added during the next stage of cluster creation - This is due to process connections requiring the cluster name, which is not visible from within the process, but procname is. <strong>Our suggestion is to use the process type</strong> (<code>proctype</code>) <strong>with a number</strong> e.g. <code>gateway1</code>.</li>
 </ul>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/gw_cluster_details.png" alt="Gateway Cluster Details" width="90%"/>
+    <img src="../workshop/graphics/gw_cluster_details.png" alt="Gateway Cluster Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1250,13 +1250,13 @@
 <li>
 <p>Select <code>Run on kdb scaling group</code> for the Cluster running option.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_running.png" alt="Gateway Cluster Running" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_running.png" alt="Gateway Cluster Running" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Choose your group in the dropdown in the <code>Kdb scaling group details</code> section.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+    <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1268,7 +1268,7 @@
 <li>
 <p>Leave Tags as empty and select <code>Next</code> to go to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/rdb_node_details.png" alt="Gateway Node Details" width="90%"/>
+    <img src="../workshop/graphics/rdb_node_details.png" alt="Gateway Node Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1302,7 +1302,7 @@
 </table>
 <p>This specified initialization script and the command line arguments will set up the necessary environment for your cluster.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/gw_add_code.png" alt="Gateway Add Code" width="90%"/>
+    <img src="../workshop/graphics/gw_add_code.png" alt="Gateway Add Code" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1327,7 +1327,7 @@
 <li>
 <p>Choose a name for your cluster. As this is a sample feed and not a "production" intended process, please name it <code>feed1</code>.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/feed_cluster_details.png" alt="Feed Cluster Details" width="90%"/>
+    <img src="../workshop/graphics/feed_cluster_details.png" alt="Feed Cluster Details" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1336,19 +1336,19 @@
 <li>
 <p>Select <code>Run on kdb scaling group</code> for the Cluster running option.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_cluster_running.png" alt="Feed Cluster Running" width="90%"/>
+    <img src="../workshop/graphics/discovery_cluster_running.png" alt="Feed Cluster Running" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Choose your group in the dropdown in the <code>Kdb scaling group details</code> section.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
+    <img src="../workshop/graphics/kdb_scaling_group_details.png" alt="Kdb Scaling Group Details" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>In the <code>Node details</code> section, set the <code>Memory reservation per node</code> to the minimum allowed (6 MiB) and leave the rest blank.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_memory_reservation.png" alt="Feed Memory Reservation" width="90%"/>
+    <img src="../workshop/graphics/discovery_memory_reservation.png" alt="Feed Memory Reservation" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1385,7 +1385,7 @@
 </table>
 <p>This specified initialization script and the command line arguments will set up the necessary environment for your cluster.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/feed_add_code.png" alt="Feed Add Code" width="90%"/>
+    <img src="../workshop/graphics/feed_add_code.png" alt="Feed Add Code" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1397,7 +1397,7 @@
 <li>
 <p>Leave everything as blank and click <code>Next</code> to move on to the next page.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/discovery_config_options.png" alt="Feed Config Options" width="90%"/>
+    <img src="../workshop/graphics/discovery_config_options.png" alt="Feed Config Options" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1413,7 +1413,7 @@
 <h2 id="errors-in-cluster-creation">Errors in cluster creation</h2>
 <p>On cluster creation, most errors will result in your cluster going to a <code>Create failed</code> state.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/cluster_failure.png" alt="Cluster failure" width="90%"/>
+    <img src="../workshop/graphics/cluster_failure.png" alt="Cluster failure" width="90%"/>
 </p>
 
 <p>If that is the case you should:</p>
@@ -1421,7 +1421,7 @@
 <li>
 <p>Click the cluster name in the <code>Clusters</code> section of your environment.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/cluster_select.png" alt="Select Cluster" width="90%"/>
+    <img src="../workshop/graphics/cluster_select.png" alt="Select Cluster" width="90%"/>
 </p></p>
 </li>
 <li>
@@ -1430,7 +1430,7 @@
 <li>
 <p>If you click the LogStream for an individual log it will take you to AWS CloudWatch where you can filter the messages for keywords or for messages in a certain time window.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/cluster_logs.png" alt="Select Cluster Logs" width="90%"/>
+    <img src="../workshop/graphics/cluster_logs.png" alt="Select Cluster Logs" width="90%"/>
 </p></p>
 </li>
 </ul>

--- a/08-createec2/index.html
+++ b/08-createec2/index.html
@@ -764,12 +764,12 @@
 <h2 id="create-a-windows-ec2-instance">Create a Windows EC2 Instance</h2>
 <p>Navigate to the EC2 service.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/navigate_ec2.png" alt="Navigate to the EC2 service" width="90%"/>
+    <img src="../workshop/graphics/navigate_ec2.png" alt="Navigate to the EC2 service" width="90%"/>
 </p>
 
 <p>Select <code>Launch instance</code> to create a new EC2 instance.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_launch.png" alt="Select launch instance" width="90%"/>
+    <img src="../workshop/graphics/ec2_launch.png" alt="Select launch instance" width="90%"/>
 </p>
 
 <p>Most options here can be left as their defaults. Here are the ones that need selected/changing:</p>
@@ -777,88 +777,88 @@
 <li>
 <p>Select "Windows" from the <code>Quick Start</code> options.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/ec2_application.png" alt="Select windows quick start" width="90%"/>
+    <img src="../workshop/graphics/ec2_application.png" alt="Select windows quick start" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>We need to create a new key pair: Select <code>Create new key pair</code>.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/ec2_keypair_button.png" alt="Select create new key pair" width="90%"/>
+    <img src="../workshop/graphics/ec2_keypair_button.png" alt="Select create new key pair" width="90%"/>
 </p></p>
 </li>
 <li>
 <p>Enter a name for your key pair, leave the key pair type as <code>RSA</code> and the file format as <code>.pem</code>. This will download a key file to you PC which you will use to connect to the instance.</p>
 <p><p style="text-align: center">
-    <img src="workshop/graphics/create_key_pair.png" alt="Create new key pair" width="90%"/>
+    <img src="../workshop/graphics/create_key_pair.png" alt="Create new key pair" width="90%"/>
 </p></p>
 </li>
 </ol>
 <p>The network should be in the same VPC as your cluster. Select <code>Create security group</code> that allows Remote Desktop Protocol (RDP) connections from anywhere.
     - This is only for the purposes of the MVP. For customising see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-security-groups.html">this page</a> on security groups.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_network.png" alt="EC2 network" width="90%"/>
+    <img src="../workshop/graphics/ec2_network.png" alt="EC2 network" width="90%"/>
 </p>
 
 <h2 id="adding-your-new-security-group-to-you-ec2">Adding your new security group to you EC2</h2>
 <p>Now we need to add the security group of your cluster to your EC2.</p>
 <p>Navigate to EC2 service.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_navigate.png" alt="Navigate to EC2" width="90%"/>
+    <img src="../workshop/graphics/ec2_navigate.png" alt="Navigate to EC2" width="90%"/>
 </p>
 
 <p>Select <code>Instances (running)</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_navigate2.png" alt="Select Instance running" width="90%"/>
+    <img src="../workshop/graphics/ec2_navigate2.png" alt="Select Instance running" width="90%"/>
 </p>
 
 <p>Open your EC2 Instance.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
 </p>
 
 <p>Select <code>Actions</code> -&gt; <code>Security</code> -&gt; <code>Change security groups</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_add_security.png" alt="Select change security groups" width="90%"/>
+    <img src="../workshop/graphics/ec2_add_security.png" alt="Select change security groups" width="90%"/>
 </p>
 
 <p>Search and select the security group that is on your clusters, select <code>Add security group</code> then <code>Save</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_add_security2.png" alt="Add security group" width="90%"/>
+    <img src="../workshop/graphics/ec2_add_security2.png" alt="Add security group" width="90%"/>
 </p>
 
 <p>You should now have two security groups, one from the launch wizard, and the one you added manually that is also attached to your clusters.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/ec2_security.png" alt="Security group example" width="90%"/>
+    <img src="../workshop/graphics/ec2_security.png" alt="Security group example" width="90%"/>
 </p>
 
 <h2 id="connecting-to-your-ec2-instance">Connecting to your EC2 Instance</h2>
 <p>Open your EC2 Instance.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect1.png" alt="Open EC2 instance" width="90%"/>
 </p>
 
 <p>Select <code>Connect</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect2.png" alt="Select connect" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect2.png" alt="Select connect" width="90%"/>
 </p>
 
 <h3 id="get-your-password">Get your password</h3>
 <p>This only needs to be done once. Once you have this password you can skip this step.</p>
 <p>Select <code>Get password</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect3.png" alt="Get password" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect3.png" alt="Get password" width="90%"/>
 </p>
 
 <p>Upload the <code>.pem</code> that was saved to you PC earlier (alternativly you can just paste the contents of this file in the text box).</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect4.png" alt="Upload .pem file" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect4.png" alt="Upload .pem file" width="90%"/>
 </p>
 
 <p>This will return the value of your password. Keep a note of this password as you will need it to connect your EC2.</p>
 <h3 id="connect">Connect</h3>
 <p>Download the remote desktop file.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/EC2_connect5.png" alt="Dowload remote desktop file" width="90%"/>
+    <img src="../workshop/graphics/EC2_connect5.png" alt="Dowload remote desktop file" width="90%"/>
 </p>
 
 <p>Run this file and enter the password you recieved above when promted. You should now be connected to the Windows remote desktop.</p>

--- a/09-clusterconnectionstring/index.html
+++ b/09-clusterconnectionstring/index.html
@@ -835,23 +835,23 @@
 <h2 id="create-a-user-if-manually-set-up-not-useing-terraform">Create a user (If manually set up (not useing Terraform))</h2>
 <p>In your kdb environment, go to the <code>Users</code> tab and select <code>Add user</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/create_user_button.png" alt="Create user button" width="90%"/>
+    <img src="../workshop/graphics/create_user_button.png" alt="Create user button" width="90%"/>
 </p>
 
 <p>Give it a name and select the <code>IAM role</code> you created above.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/create_user.png" alt="Add user" width="90%"/>
+    <img src="../workshop/graphics/create_user.png" alt="Add user" width="90%"/>
 </p>
 
 <h2 id="generate-connection-string">Generate Connection String</h2>
 <p>On the <code>Users</code> tab, copy the links for <code>IAM role</code> and <code>User ARN</code> for the user.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/user_details.png" alt="User details" width="90%"/>
+    <img src="../workshop/graphics/user_details.png" alt="User details" width="90%"/>
 </p>
 
 <p>Navigate to <code>CloudShell</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/cloudshell.png" alt="Navigate to CloudShell" width="90%"/>
+    <img src="../workshop/graphics/cloudshell.png" alt="Navigate to CloudShell" width="90%"/>
 </p>
 
 <p>Replace <code>&lt;ARN_COPIED_FROM_ABOVE&gt;</code> with the <code>IAM Role</code> copied above and run the following (this will not return anything):</p>
@@ -865,7 +865,7 @@ $(aws sts assume-role \
 <p>This lets you assume the role that you have just created by taking the values returned from the <code>aws sts assume-role</code> command and setting them in your <code>AWS_ACCESS_KEY_ID</code>, e.t.c. environment variables. NOTE - if you need to switch back to your own user within the CloudShell, you will need to run <code>unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN</code> to unset these environment variables.</p>
 <p>Copy your kdb Environment ID:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/kdbenv_id.png" alt="Get you kdb env ID" width="90%"/>
+    <img src="../workshop/graphics/kdbenv_id.png" alt="Get you kdb env ID" width="90%"/>
 </p>
 
 <p>Replace <code>&lt;YOUR_KDB_ENVIRONMENT_ID&gt;</code> with your kdb environment ID, <code>&lt;USER_ARN_COPIED_ABOVE&gt;</code> with the <code>User ARN</code>, and <code>&lt;NAME_OF_CLUSTER&gt;</code> with the name of the cluster you want to connect to. Run the following:</p>
@@ -873,7 +873,7 @@ $(aws sts assume-role \
 </code></pre>
 <p>This will return a large connection string which can be used to connect to your cluster.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/connection_string.png" alt="Connection string example" width="90%"/>
+    <img src="../workshop/graphics/connection_string.png" alt="Connection string example" width="90%"/>
 </p>
 
 

--- a/10-setupqStudio/index.html
+++ b/10-setupqStudio/index.html
@@ -681,29 +681,29 @@
 <h2 id="download-qstudio">Download qStudio</h2>
 <p>Navigate to the <a href="https://www.timestored.com/qstudio/download">TimeStored</a> website and download the relavent version (usually x64).</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/qStudio_Download1.png" alt="Download button on qStudio website" width="90%"/>
+    <img src="../workshop/graphics/qStudio_Download1.png" alt="Download button on qStudio website" width="90%"/>
 </p>
 
 <p>Download the <a href="https://www.microsoft.com/en-gb/download/details.aspx?id=26999">Microsoft C++ 2010 service pack</a> (there is a specific DLL from this that you need that is usually installed on Windows machines).</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/MSpack_download.png" alt="Download MSPack" width="90%"/>
+    <img src="../workshop/graphics/MSpack_download.png" alt="Download MSPack" width="90%"/>
 </p>
 
 <p>Select the relevant version (usually x64).**</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/MSpack_download2.png" alt="Download MSPack select version" width="90%"/>
+    <img src="../workshop/graphics/MSpack_download2.png" alt="Download MSPack select version" width="90%"/>
 </p>
 
 <p>Run the file that was just downloaded.</p>
 <p>Search for ‘Edit Environment variables’ and add <code>SSL_VERIFY_SERVER=NO</code> as one of them.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/edit_env_var1.png" alt="Edit Environment Variables 1" width="90%"/>
+    <img src="../workshop/graphics/edit_env_var1.png" alt="Edit Environment Variables 1" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="workshop/graphics/edit_env_var2.png" alt="Edit Environment Variables 2" width="90%"/>
+    <img src="../workshop/graphics/edit_env_var2.png" alt="Edit Environment Variables 2" width="90%"/>
 </p>
 <p style="text-align: center">
-    <img src="workshop/graphics/edit_env_var3.png" alt="Edit Environment Variables 3" width="90%"/>
+    <img src="../workshop/graphics/edit_env_var3.png" alt="Edit Environment Variables 3" width="90%"/>
 </p>
 
 

--- a/11-connectingusingqStudio/index.html
+++ b/11-connectingusingqStudio/index.html
@@ -623,17 +623,17 @@
 <h1 id="connecting-using-qstudio">Connecting Using qStudio</h1>
 <p>Open qStudio, right-click on <code>Servers</code> in the top left corner and select <code>Add Server</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/Servers_qStudio1.png" alt="Add Server Connection" width="90%"/>
+    <img src="../workshop/graphics/Servers_qStudio1.png" alt="Add Server Connection" width="90%"/>
 </p>
 
 <p>You will then see a pop-up showing the server properties. This is where you will add the information from the connection string (details below in the next step).</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/Server_Properties1.png" alt="Server Properties" width="90%"/>
+    <img src="../workshop/graphics/Server_Properties1.png" alt="Server Properties" width="90%"/>
 </p>
 
 <p>Follow the step in our <a href="https://dataintellecttech.github.io/TorQ-Amazon-FinSpace-Starter-Pack/08-clusterconnectionstring/#generate-connection-string">Generate Connection String section</a> to get a fresh connection string. The generated connection string provides you with everything you need to fill the boxes above. See the below connection string for an example:</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/Connectionstring3.png" alt="Connection String" width="90%"/>
+    <img src="../workshop/graphics/Connectionstring3.png" alt="Connection String" width="90%"/>
 </p>
 
 <p>The required fields in the Server Properties screen are contained within the connection string and are colon separated. Here,</p>
@@ -643,7 +643,7 @@
 <p><code>Username:</code> david-finspace</p>
 <p><code>Password:</code> Host=vpce-063d07d253dde398d-19p5nh4w.vpce-svc-0b408455b16d79292.us-west-2.vpce.amazonaws.com&amp;Port=443&amp;User=david-finspace&amp;Action=finspace%3AConnectKxCluster&amp;X-Amz-Security-Token=IQoJb3JpZ2luX2VjEDUaCXVzLXdlc3QtMiJGMEQCIFOmCCIAE5hyh0obtgV8TeS9jCglbxFPEossH5f4vRhrAiAIaxSHF%2FQhjqACSlmwlLTNJBvx658bQwyiH9LVz20ehSr4AgguEAIaDDc2NjAxMjI4NjAwMyIMl3TMLJjQytFtFLaiKtUCbJrjypNOC5U8GwttcBfln2SV%2FJclct%2FmeDtnUCUcVB3bzcCUOpGQFXUR%2FtonWVO0ZO1SUu%2Bna%2Bs0l0UfMu7K7qDOQhszg1%2Fxdblx0TRi70GVunATeJlpppyQeZNUk9RHSOvGPCN8VKGBJmisbeo3bJb7MvVLak1lgVdLn%2FxUIS0uTfA62PbzU6LPE1nj85bupgLrvAMlSwvZMy3pVXJaN%2BBvk0mulmCvIYfqlqL%2FcjvWbOMQdyXsdAYCO4TRpA7I38Jmfr9h1oee2JVvVMCu41yRQhbAqtqgvNwrhgSyOQASAJSVGiIPHiXyGz5KefntOfq1zADleUrUg0Nvh6EPFj%2FavNsHZyBSapvUVVsx%2FA9aI2aHeg5P%2FtCifq%2Bnxg5vyKSX4GcB7P40pKs3Ymeb3yAUllN2tJ5VXlx7SI3p8jfTB8k72BeOzu%2BLbWs5gtb%2BlZG1cSQwzKSHrwY6wAEpzwyEjjuh50PM6OZgRBNgBEOiqLaTHqjBv7VHcjsF5FnpJqZ2AhBtQXXkFiItA%2FSZ7B0aGbL0sYJ8v7WZZIMtAvg4e0ve9VBYXf4hnl5i82T5EJfAy727E9e25Wwb%2FILZAeOjdTY0IhcgvWlLCeBJNEHEMO8h8yupkLfFQHlNvF14wrH1U8bSd934M8k%2F22%2FDTrZFlVQXe%2FeLYt%2FxOBEHfHWiMH51v2IDv39%2B%2B7%2FGq3XmrcNymPQQ0HcoJEK%2BTjg%3D&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Date=20240301T130412Z&amp;X-Amz-SignedHeaders=host&amp;X-Amz-Expires=900&amp;X-Amz-Credential=ASIA3EWPD4QZXLHMX4GY%2F20240301%2Fus-west-2%2Ffinspace-apricot%2Faws4_request&amp;X-Amz-Signature=c134f0dc1f0cba738c0bf8547c9ca8702593ea9e9b89ee2d17892fd379524d30</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/CompleteServers1.png" alt="All Servers" width="90%"/>
+    <img src="../workshop/graphics/CompleteServers1.png" alt="All Servers" width="90%"/>
 </p>
 
 

--- a/12-runningqueries/index.html
+++ b/12-runningqueries/index.html
@@ -625,12 +625,12 @@
 <p>For queries to be ran through the gateway, we must update some preferences on qStudio. Go to <code>Settings</code> -&gt; <code>Preferences</code> -&gt; <code>Connections</code> tab.</p>
 <p>We will need to uncheck the box labelled <code>Wrap query sent to server</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/Preferences2.png" alt="Preferences" width="90%"/>
+    <img src="../workshop/graphics/Preferences2.png" alt="Preferences" width="90%"/>
 </p>
 
 <p>The queries below should then all run successfully!</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/RunningQueries.png" alt="qStudio Queries" width="90%"/>
+    <img src="../workshop/graphics/RunningQueries.png" alt="qStudio Queries" width="90%"/>
 </p>
 
 <p>Example queries are listed below:</p>

--- a/14-takingitdown/index.html
+++ b/14-takingitdown/index.html
@@ -752,12 +752,12 @@
 <h2 id="deleting-clusters">Deleting clusters</h2>
 <p>From your Kdb environment select the cluster you want to delete and select <code>Delete</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_cluster1.png" alt="Select delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_cluster1.png" alt="Select delete cluster" width="90%"/>
 </p>
 
 <p>On the confirmation dialog box, enter confirm then select <code>Delete</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_cluster2.png" alt="Delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_cluster2.png" alt="Delete cluster" width="90%"/>
 </p>
 
 <h2 id="deleting-your-dataview">Deleting your dataview</h2>
@@ -766,7 +766,7 @@
 <li>Select your kdb environment and navigate to the <code>Databases</code> tab. Then select the database your dataview is associated with:</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
+    <img src="../workshop/graphics/database_tab.png" alt="Database tab" width="90%"/>
 </p>
 
 <ol>
@@ -774,14 +774,14 @@
 <li>Click the <code>Delete</code> button</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_dataview.png" alt="Delete Dataview" width="90%"/>
+    <img src="../workshop/graphics/delete_dataview.png" alt="Delete Dataview" width="90%"/>
 </p>
 
 <ol>
 <li>On the confirmation dialog box, type "confirm" and then click the <code>Delete</code> button.</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/confirm_delete_dataview.png" alt="Delete Dataview confirm" width="90%"/>
+    <img src="../workshop/graphics/confirm_delete_dataview.png" alt="Delete Dataview confirm" width="90%"/>
 </p>
 
 <h2 id="deleting-your-shared-volume">Deleting your Shared Volume</h2>
@@ -789,14 +789,14 @@
 <li>Select your kdb environment and navigate to the <code>Volumes</code> tab. Then select the volume you like to delete and click <code>Delete</code></li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_volume.png" alt="Delete Volume" width="90%"/>
+    <img src="../workshop/graphics/delete_volume.png" alt="Delete Volume" width="90%"/>
 </p>
 
 <ol>
 <li>On the confirmation dialog box, type "confirm" and then click the <code>Delete</code> button.</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/confirm_delete_volume.png" alt="Delete Volume confirm" width="90%"/>
+    <img src="../workshop/graphics/confirm_delete_volume.png" alt="Delete Volume confirm" width="90%"/>
 </p>
 
 <h2 id="deleting-your-kdb-scaling-group">Deleting your Kdb Scaling Group</h2>
@@ -805,25 +805,25 @@
 <li>Select your kdb environment and navigate to the <code>Kdb scaling groups</code> tab. Then select the scaling group you like to delete and click <code>Delete</code></li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_scaling_groups.png" alt="Delete Scaling Group" width="90%"/>
+    <img src="../workshop/graphics/delete_scaling_groups.png" alt="Delete Scaling Group" width="90%"/>
 </p>
 
 <ol>
 <li>On the confirmation dialog box, type "confirm" and then click the <code>Delete</code> button.</li>
 </ol>
 <p style="text-align: center">
-    <img src="workshop/graphics/confirm_delete_scaling_groups.png" alt="Delete Scaling Group confirm" width="90%"/>
+    <img src="../workshop/graphics/confirm_delete_scaling_groups.png" alt="Delete Scaling Group confirm" width="90%"/>
 </p>
 
 <h2 id="deleting-your-database">Deleting your database</h2>
 <p>From your Kdb environment select the <code>Databases</code> tab, select the database you want to delete and select <code>Delete</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_database1.png" alt="Delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_database1.png" alt="Delete cluster" width="90%"/>
 </p>
 
 <p>On the confirmation dialog box, enter confirm then select <code>Delete</code>.</p>
 <p style="text-align: center">
-    <img src="workshop/graphics/delete_database2.png" alt="Delete cluster" width="90%"/>
+    <img src="../workshop/graphics/delete_database2.png" alt="Delete cluster" width="90%"/>
 </p>
 
 


### PR DESCRIPTION
On master the images are in the right places for the paths, but in the `gh-pages` branch they are not.
All html fixes are `index.html` inside a subdir labelled for the page, meaning that we need to go back up one level before looking for images, hence adding the `../` to all paths.